### PR TITLE
update compute_dt to MPI standards&

### DIFF
--- a/miniapps/convection/GlobalConvection2D.jl
+++ b/miniapps/convection/GlobalConvection2D.jl
@@ -54,8 +54,8 @@ end
 function circular_perturbation!(T, δT, xc, yc, r, xvi)
 
     @parallel_indices (i, j) function _circular_perturbation!(T, δT, xc, yc, r, x, y)
-        @inbounds if (((x[i]-xc ))^2 + ((y[j] - yc))^2) ≤ r^2
-            T[i, j] *= δT/100 + 1
+        @inbounds if (((x[i] - xc))^2 + ((y[j] - yc))^2) ≤ r^2
+            T[i, j] *= δT / 100 + 1
         end
         return nothing
     end
@@ -67,8 +67,8 @@ function random_perturbation!(T, δT, xbox, ybox, xvi)
 
     @parallel_indices (i, j) function _random_perturbation!(T, δT, xbox, ybox, x, y)
         @inbounds if (xbox[1] ≤ x[i] ≤ xbox[2]) && (abs(ybox[1]) ≤ abs(y[j]) ≤ abs(ybox[2]))
-            δTi = δT * (rand() -  0.5) # random perturbation within ±δT [%]
-            T[i, j] *= δTi/100 + 1
+            δTi = δT * (rand() - 0.5) # random perturbation within ±δT [%]
+            T[i, j] *= δTi / 100 + 1
         end
         return nothing
     end
@@ -202,14 +202,14 @@ function thermal_convection2D(; ar=8, ny=16, nx=ny*8, figdir="figs2D", thermal_p
         ylims!(ax1, -2890, 0)
         ylims!(ax2, -2890, 0)
         hideydecorations!(ax2)
-        save( joinpath(figdir, "initial_profile.png"), fig)
+        save(joinpath(figdir, "initial_profile.png"), fig)
         fig
     end
 
     # Time loop
     t, it = 0.0, 0
     local iters
-    while (t/(1e6 * 3600 * 24 *365.25)) < 4.5e3
+    while (t / (1e6 * 3600 * 24 * 365.25)) < 4.5e3
         # Stokes solver ----------------
         args = (; T = thermal.Tc, P = stokes.P, depth = depth, dt=Inf)
         iters = solve!(
@@ -227,7 +227,7 @@ function thermal_convection2D(; ar=8, ny=16, nx=ny*8, figdir="figs2D", thermal_p
             iterMax=250e3,
             nout=1e3,
         );
-        dt = compute_dt(stokes, di, dt_diff)
+        dt = compute_dt(stokes, di, dt_diff, igg)
         # ------------------------------
 
         # Thermal solver ---------------

--- a/miniapps/convection/GlobalConvection3D.jl
+++ b/miniapps/convection/GlobalConvection3D.jl
@@ -71,8 +71,8 @@ function random_perturbation!(T, δT, xbox, ybox, zbox, xvi)
             (ybox[1] ≤ y[j] ≤ ybox[2]) && 
             (abs(zbox[1]) ≤ abs(z[k]) ≤ abs(zbox[2]))
         @inbounds if inbox
-            δTi         = δT * (rand() -  0.5) # random perturbation within ±δT [%]
-            T[i, j, k] *= δTi/100 + 1
+            δTi         = δT * (rand() - 0.5) # random perturbation within ±δT [%]
+            T[i, j, k] *= δTi / 100 + 1
         end
         return nothing
     end
@@ -80,7 +80,7 @@ function random_perturbation!(T, δT, xbox, ybox, zbox, xvi)
     @parallel (@idx size(T)) _random_perturbation!(T, δT, xbox, ybox, zbox, xvi...)
 end
 
-Rayleigh_number(ρ, α, ΔT, κ, η0) = ρ * 9.81 * α * ΔT * 2890e3^3 * inv(κ * η0) 
+Rayleigh_number(ρ, α, ΔT, κ, η0) = ρ * 9.81 * α * ΔT * 2890e3^3 * inv(κ * η0)
 
 function thermal_convection3D(; ar=8, nz=16, nx=ny*8, ny=nx, figdir="figs3D", thermal_perturbation = :random)
     
@@ -211,19 +211,19 @@ function thermal_convection3D(; ar=8, nz=16, nx=ny*8, ny=nx, figdir="figs3D", th
         ylims!(ax1, minimum(xvi[3])./1e3, 0)
         ylims!(ax2, minimum(xvi[3])./1e3, 0)
         hideydecorations!(ax2)
-        save( joinpath(figdir, "initial_profile.png"), fig)
+        save(joinpath(figdir, "initial_profile.png"), fig)
         fig
     end
 
     # Time loop
     t, it = 0.0, 0
     local iters
-    while (t/(1e6 * 3600 * 24 *365.25)) < 4.5e3
- 
+    while (t / (1e6 * 3600 * 24 * 365.25)) < 4.5e3
+
         # Update arguments needed to compute several physical properties
         # e.g. density, viscosity, etc -
-        args = (; T = thermal.Tc, P = stokes.P, depth = depth, dt=Inf)
-    
+        args = (; T=thermal.Tc, P=stokes.P, depth=depth, dt=Inf)
+
         # Stokes solver ----------------
         iters = solve!(
             stokes,
@@ -242,7 +242,7 @@ function thermal_convection3D(; ar=8, nz=16, nx=ny*8, ny=nx, figdir="figs3D", th
         );
 
         println("starting non linear iterations")
-        dt = compute_dt(stokes, di, dt_diff)
+        dt = compute_dt(stokes, di, dt_diff, igg)
         # ------------------------------
 
         # Thermal solver ---------------
@@ -286,7 +286,7 @@ function thermal_convection3D(; ar=8, nz=16, nx=ny*8, ny=nx, figdir="figs3D", th
             Colorbar(fig[3,2], h3)
             Colorbar(fig[4,2], h4)
             fig
-            save( joinpath(figdir, "$(it).png"), fig)
+            save(joinpath(figdir, "$(it).png"), fig)
             
             # save vtk time series 
             data_c = (; Temperature = Array(thermal.Tc),  TauII = Array(stokes.τ.II), Density=Array(ρg[3]./9.81))

--- a/src/MetaJustRelax.jl
+++ b/src/MetaJustRelax.jl
@@ -75,7 +75,11 @@ function environment!(model::PS_Setup{T,N}) where {T,N}
             assign!,
             tupleize,
             compute_maxloc!,
-            continuation_log
+            continuation_log,
+            mean_mpi,
+            norm_mpi,
+            minimum_mpi,
+            maximum_mpi
 
         include(joinpath(@__DIR__, "boundaryconditions/BoundaryConditions.jl"))
         export pureshear_bc!,

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -342,6 +342,31 @@ Compute the time step `dt` for the velocity field `S.V` and the diffusive maximu
     dt_adv = mapreduce(x -> x[1] * inv(maximum(abs.(x[2]))), max, zip(di, V)) * n
     return min(dt_diff, dt_adv)
 end
+"""
+    compute_dt(S::StokesArrays, di, igg)
+
+Compute the time step `dt` for the velocity field `S.V` for a regular gridwith grid spacing `di`.
+The implicit global grid variable `igg` implies that the time step is calculated globally and not
+separately on each block.   
+"""
+@inline compute_dt(S::StokesArrays, di, igg) = compute_dt(@velocity(S), di, Inf, igg)
+
+"""
+    compute_dt(S::StokesArrays, di, dt_diff)
+
+Compute the time step `dt` for the velocity field `S.V` and the diffusive maximum time step 
+`dt_diff` for a regular gridwith grid spacing `di`. The implicit global grid variable `igg`
+implies that the time step is calculated globally and not separately on each block.
+"""
+@inline function compute_dt(S::StokesArrays, di, dt_diff, igg)
+    return compute_dt(@velocity(S), di, dt_diff, igg)
+end
+
+@inline function compute_dt(V::NTuple, di, dt_diff, igg)
+    n = inv(length(V) + 0.1)
+    dt_adv = mapreduce(x -> x[1] * inv(maximum_mpi(abs.(x[2]))), max, zip(di, V)) * n
+    return min(dt_diff, dt_adv)
+end
 
 @inline tupleize(v) = (v,)
 @inline tupleize(v::Tuple) = v

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -346,23 +346,23 @@ end
     compute_dt(S::StokesArrays, di, igg)
 
 Compute the time step `dt` for the velocity field `S.V` for a regular gridwith grid spacing `di`.
-The implicit global grid variable `igg` implies that the time step is calculated globally and not
+The implicit global grid variable `I` implies that the time step is calculated globally and not
 separately on each block.   
 """
-@inline compute_dt(S::StokesArrays, di, igg) = compute_dt(@velocity(S), di, Inf, igg)
+@inline compute_dt(S::StokesArrays, di, I::IGG) = compute_dt(@velocity(S), di, Inf, I::IGG)
 
 """
     compute_dt(S::StokesArrays, di, dt_diff)
 
 Compute the time step `dt` for the velocity field `S.V` and the diffusive maximum time step 
-`dt_diff` for a regular gridwith grid spacing `di`. The implicit global grid variable `igg`
+`dt_diff` for a regular gridwith grid spacing `di`. The implicit global grid variable `I`
 implies that the time step is calculated globally and not separately on each block.
 """
-@inline function compute_dt(S::StokesArrays, di, dt_diff, igg)
-    return compute_dt(@velocity(S), di, dt_diff, igg)
+@inline function compute_dt(S::StokesArrays, di, dt_diff,  I::IGG)
+    return compute_dt(@velocity(S), di, dt_diff,  I::IGG)
 end
 
-@inline function compute_dt(V::NTuple, di, dt_diff, igg)
+@inline function compute_dt(V::NTuple, di, dt_diff,  I::IGG)
     n = inv(length(V) + 0.1)
     dt_adv = mapreduce(x -> x[1] * inv(maximum_mpi(abs.(x[2]))), max, zip(di, V)) * n
     return min(dt_diff, dt_adv)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -358,11 +358,11 @@ Compute the time step `dt` for the velocity field `S.V` and the diffusive maximu
 `dt_diff` for a regular gridwith grid spacing `di`. The implicit global grid variable `I`
 implies that the time step is calculated globally and not separately on each block.
 """
-@inline function compute_dt(S::StokesArrays, di, dt_diff,  I::IGG)
-    return compute_dt(@velocity(S), di, dt_diff,  I::IGG)
+@inline function compute_dt(S::StokesArrays, di, dt_diff, I::IGG)
+    return compute_dt(@velocity(S), di, dt_diff, I::IGG)
 end
 
-@inline function compute_dt(V::NTuple, di, dt_diff,  I::IGG)
+@inline function compute_dt(V::NTuple, di, dt_diff, I::IGG)
     n = inv(length(V) + 0.1)
     dt_adv = mapreduce(x -> x[1] * inv(maximum_mpi(abs.(x[2]))), max, zip(di, V)) * n
     return min(dt_diff, dt_adv)

--- a/src/stokes/Stokes2D.jl
+++ b/src/stokes/Stokes2D.jl
@@ -48,6 +48,7 @@ import JustRelax: elastic_iter_params!, PTArray, Velocity, SymmetricTensor
 import JustRelax:
     Residual, StokesArrays, PTStokesCoeffs, AbstractStokesModel, ViscoElastic, IGG
 import JustRelax: compute_maxloc!, solve!
+import JustRelax: mean_mpi, norm_mpi, maximum_mpi, minimum_mpi
 
 export solve!
 
@@ -478,13 +479,13 @@ function JustRelax.solve!(
             Vmin, Vmax = extrema(stokes.V.Vx)
             Pmin, Pmax = extrema(stokes.P)
             push!(
-                norm_Rx, norm(stokes.R.Rx) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Rx))
+                norm_Rx, norm_mpi(stokes.R.Rx) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Rx))
             )
             push!(
-                norm_Ry, norm(stokes.R.Ry) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Ry))
+                norm_Ry, norm_mpi(stokes.R.Ry) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Ry))
             )
-            push!(norm_∇V, norm(stokes.∇V) / (Vmax - Vmin) * lx / sqrt(length(stokes.∇V)))
-            err = max(norm_Rx[end], norm_Ry[end], norm_∇V[end])
+            push!(norm_∇V, norm_mpi(stokes.∇V) / (Vmax - Vmin) * lx / sqrt(length(stokes.∇V)))
+            err = maximum_mpi(norm_Rx[end], norm_Ry[end], norm_∇V[end])
             push!(err_evo1, err)
             push!(err_evo2, iter)
             if igg.me == 0 && ((verbose && err > ϵ) || iter == iterMax)
@@ -597,11 +598,11 @@ function JustRelax.solve!(
             @parallel (@idx ni) compute_Res!(
                 stokes.R.Rx, stokes.R.Ry, stokes.P, @stress(stokes)..., ρg..., _di...
             )
-            errs = maximum.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
+            errs = maximum_mpi.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
             push!(norm_Rx, errs[1])
             push!(norm_Ry, errs[2])
             push!(norm_∇V, errs[3])
-            err = maximum(errs)
+            err = maximum_mpi(errs)
             push!(err_evo1, err)
             push!(err_evo2, iter)
             if igg.me == 0 && ((verbose && err > ϵ) || iter == iterMax)
@@ -738,11 +739,11 @@ function JustRelax.solve!(
             @parallel (@idx ni) compute_Res!(
                 stokes.R.Rx, stokes.R.Ry, stokes.P, @stress(stokes)..., ρg..., _di...
             )
-            errs = maximum.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
+            errs = maximum_mpi.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
             push!(norm_Rx, errs[1])
             push!(norm_Ry, errs[2])
             push!(norm_∇V, errs[3])
-            err = maximum(errs)
+            err = maximum_mpi(errs)
             push!(err_evo1, err)
             push!(err_evo2, iter)
             if igg.me == 0 && ((verbose && err > ϵ) || iter == iterMax)
@@ -878,11 +879,11 @@ function JustRelax.solve!(
             @parallel (@idx ni) compute_Res!(
                 stokes.R.Rx, stokes.R.Ry, stokes.P, @stress(stokes)..., ρg..., _di...
             )
-            errs = maximum.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
+            errs = maximum_mpi.((abs.(stokes.R.Rx), abs.(stokes.R.Ry), abs.(stokes.R.RP)))
             push!(norm_Rx, errs[1])
             push!(norm_Ry, errs[2])
             push!(norm_∇V, errs[3])
-            err = maximum(errs)
+            err = maximum_mpi(errs)
             push!(err_evo1, err)
             push!(err_evo2, iter)
             if igg.me == 0 && (verbose || iter == iterMax)

--- a/src/stokes/Stokes2D.jl
+++ b/src/stokes/Stokes2D.jl
@@ -479,12 +479,16 @@ function JustRelax.solve!(
             Vmin, Vmax = extrema(stokes.V.Vx)
             Pmin, Pmax = extrema(stokes.P)
             push!(
-                norm_Rx, norm_mpi(stokes.R.Rx) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Rx))
+                norm_Rx,
+                norm_mpi(stokes.R.Rx) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Rx)),
             )
             push!(
-                norm_Ry, norm_mpi(stokes.R.Ry) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Ry))
+                norm_Ry,
+                norm_mpi(stokes.R.Ry) / (Pmax - Pmin) * lx / sqrt(length(stokes.R.Ry)),
             )
-            push!(norm_∇V, norm_mpi(stokes.∇V) / (Vmax - Vmin) * lx / sqrt(length(stokes.∇V)))
+            push!(
+                norm_∇V, norm_mpi(stokes.∇V) / (Vmax - Vmin) * lx / sqrt(length(stokes.∇V))
+            )
             err = maximum_mpi(norm_Rx[end], norm_Ry[end], norm_∇V[end])
             push!(err_evo1, err)
             push!(err_evo2, iter)

--- a/src/stokes/Stokes3D.jl
+++ b/src/stokes/Stokes3D.jl
@@ -699,10 +699,10 @@ function JustRelax.solve!(
         iter += 1
         if iter % nout == 0 && iter > 1
             cont += 1
-            push!(norm_Rx, maximum(abs.(stokes.R.Rx)))
-            push!(norm_Ry, maximum(abs.(stokes.R.Ry)))
-            push!(norm_Rz, maximum(abs.(stokes.R.Rz)))
-            push!(norm_∇V, maximum(abs.(stokes.R.RP)))
+            push!(norm_Rx, maximum_mpi(abs.(stokes.R.Rx)))
+            push!(norm_Ry, maximum_mpi(abs.(stokes.R.Ry)))
+            push!(norm_Rz, maximum_mpi(abs.(stokes.R.Rz)))
+            push!(norm_∇V, maximum_mpi(abs.(stokes.R.RP)))
             err = max(norm_Rx[cont], norm_Ry[cont], norm_Rz[cont], norm_∇V[cont])
             push!(err_evo1, err)
             push!(err_evo2, iter)

--- a/src/stokes/Stokes3D.jl
+++ b/src/stokes/Stokes3D.jl
@@ -864,10 +864,10 @@ function JustRelax.solve!(
         iter += 1
         if iter % nout == 0 && iter > 1
             cont += 1
-            push!(norm_Rx, maximum(abs.(stokes.R.Rx)))
-            push!(norm_Ry, maximum(abs.(stokes.R.Ry)))
-            push!(norm_Rz, maximum(abs.(stokes.R.Rz)))
-            push!(norm_∇V, maximum(abs.(stokes.R.RP)))
+            push!(norm_Rx, maximum_mpi(abs.(stokes.R.Rx)))
+            push!(norm_Ry, maximum_mpi(abs.(stokes.R.Ry)))
+            push!(norm_Rz, maximum_mpi(abs.(stokes.R.Rz)))
+            push!(norm_∇V, maximum_mpi(abs.(stokes.R.RP)))
             err = max(norm_Rx[cont], norm_Ry[cont], norm_Rz[cont], norm_∇V[cont])
             push!(err_evo1, err)
             push!(err_evo2, iter)

--- a/src/stokes/Stokes3D.jl
+++ b/src/stokes/Stokes3D.jl
@@ -50,6 +50,7 @@ import JustRelax: elastic_iter_params!, PTArray, Velocity, SymmetricTensor, pure
 import JustRelax:
     Residual, StokesArrays, PTStokesCoeffs, AbstractStokesModel, ViscoElastic, IGG
 import JustRelax: compute_maxloc!, solve!
+import JustRelax: mean_mpi, norm_mpi, minimum_mpi, maximum_mpi
 
 export solve!, pureshear_bc!
 


### PR DESCRIPTION
- Introduce a new `compute_dt` method with `maximum_mpi` for a global time step computation rather than locally.
- updated Residual to `maximum_mpi` in Stokes3D solver
- changed benchmarks to new `compute_dt` method
- JuliaFormatter