### PR TITLE
add workflow file for `GLMakie` and `JustPIC`

### DIFF
--- a/.github/workflows/Dependency.yml
+++ b/.github/workflows/Dependency.yml
@@ -1,0 +1,22 @@
+name: Check Dependencies
+
+on: [push, pull_request]
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for GLMakie and JustPIC dependencies
+        run: |
+          if grep -q "GLMakie" ./Project.toml; then
+            echo "GLMakie dependency found, failing the test."
+            exit 1
+          fi
+          if grep -q "JustPIC" ./Project.toml; then
+            echo "JustPIC dependency found, failing the test."
+            exit 1
+          fi
+          echo "Neither GLMakie nor JustPIC dependencies found."


### PR DESCRIPTION
This adds a workflow file that checks if `GLMakie` and `JustPIC` are a dependency and if so fails the test. This can be extended to other pkgs if necessary.
Right now it's set to execute the test on push and pull requests.