### PR TITLE
switch back to CUDA v5.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ JustRelaxCUDAExt = "CUDA"
 [compat]
 AMDGPU = "0.8, 0.9"
 Adapt = "4"
-CUDA = "~5.3.5, 5"
+CUDA = "~5.3.5"
 CellArrays = "0.2"
 GeoParams = "0.5, 0.6"
 HDF5 = "0.17.1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -18,7 +18,7 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
 AMDGPU = "0.6, 0.7, 0.8"
-CUDA = "~5.3.5, 5"
+CUDA = "~5.3.5"
 AllocCheck = "0.1"
 CellArrays = "0.2"
 GeoParams = "0.5, 0.6"


### PR DESCRIPTION
CUDA.jl versions above v5.4.0 error due to some deprecated calls, switch back to v.5.3.5 for now until this is fixed