### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macOS-latest # M-Series Chip
+          - macOS-13 # Intel Chip
           - windows-latest
         arch:
           - x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         version:
           - '1.9'
           - '1.10'
+          - 'pre'
           # - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Add CI for Apple machines with Intel Chips. `macOS-latest` uses an M-Series chip