### PR TITLE
Bug in thermal solver

### DIFF
--- a/src/thermal_diffusion/DiffusionPT_kernels.jl
+++ b/src/thermal_diffusion/DiffusionPT_kernels.jl
@@ -1,5 +1,5 @@
 isNotDirichlet(m, inds::Vararg{Int,N}) where {N} = iszero(m[inds...])
-isNotDirichlet(::Nothing, ::Vararg{Int,N}) where {N} = false
+isNotDirichlet(::Nothing, ::Vararg{Int,N}) where {N} = true
 
 ## 3D KERNELS
 


### PR DESCRIPTION
Fixes bug introduced by #273 in the thermal solver that was preventing the residual to be computed in the absence of inner boundary conditions.