### PR TITLE
Add better startup message

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [weakdeps]
@@ -45,6 +46,7 @@ ParallelStencil = "0.13.6, 0.14"
 Reexport = "1.2.2"
 StaticArrays = "1"
 Statistics = "1"
+TOML = "1.0.3"
 WriteVTK = "1.18, 1.19"
 julia = "1.9, 1.10"
 

--- a/src/JustRelax.jl
+++ b/src/JustRelax.jl
@@ -10,19 +10,23 @@ using HDF5
 using CellArrays
 using StaticArrays
 using Statistics
+using TOML
 @reexport using JustPIC
 
 function solve!() end
 #! format: off
 function __init__()
-    println("""
+    printstyled("""
          _           _   ____      _               _ _
         | |_   _ ___| |_|  _ \\ ___| | __ ___  __  (_) |
      _  | | | | / __| __| |_) / _ \\ |/ _` \\ \\/ /  | | |
     | |_| | |_| \\__ \\ |_|  _ <  __/ | (_| |>  < _ | | |
      \\___/ \\__,_|___/\\__|_| \\_\\___|_|\\__,_/_/\\_(_)/ |_|
                                                 |__/
-    """)
+    Version: $(TOML.parsefile("Project.toml")["version"])
+    Latest commit: $(strip(read(`git log -1 --pretty=%B`, String)))
+    Commit date: $(strip(read(`git log -1 --pretty=%cd`, String)))
+""", bold=true, color=:white)
 end
 #! format: on
 abstract type AbstractBackend end


### PR DESCRIPTION
This PR adds print statements of the JustRelax version, last commit info & date. This way it becomes easier in the future to debug for us if a user has a problem or we run into problems ourselves. 

```julia
         _           _   ____      _               _ _
        | |_   _ ___| |_|  _ \ ___| | __ ___  __  (_) |
     _  | | | | / __| __| |_) / _ \ |/ _` \ \/ /  | | |
    | |_| | |_| \__ \ |_|  _ <  __/ | (_| |>  < _ | | |
     \___/ \__,_|___/\__|_| \_\___|_|\__,_/_/\_(_)/ |_|
                                                |__/
    Version: 0.4.0
    Latest commit: add JR versioning to the `_init__()` function
    Commit date: Thu Jan 23 13:34:04 2025 +0100
    ```