### PR TITLE
Change to `default` color

### DIFF
--- a/src/JustRelax.jl
+++ b/src/JustRelax.jl
@@ -27,7 +27,7 @@ function __init__()
 Version: $(TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"])
 Latest commit: $(strip(read(`git log -1 --pretty=%B`, String)))
 Commit date: $(strip(read(`git log -1 --pretty=%cd`, String)))
-""", bold=true, color=:white)
+""", bold=true, color=:default)
 end
 #! format: on
 abstract type AbstractBackend end


### PR DESCRIPTION
change color of the terminal startup message to default as it was reported by @Iddingsite that it doesn't show up on white color themes