### PR TITLE
rm dublicate of `P_corrected`

### DIFF
--- a/src/stokes/StressKernels.jl
+++ b/src/stokes/StressKernels.jl
@@ -833,7 +833,6 @@ end
             τII[I...] = τII_ij
         end
 
-        Pr_c[I...] = Pr[I...] + (isinf(K) ? 0.0 : K * dt * λ[I...] * sinψ)
     end
 
     return nothing
@@ -957,7 +956,6 @@ end
             τII[I...] = τII_ij
         end
 
-        Pr_c[I...] = Pr[I...] + (isinf(K) ? 0.0 : K * dt * λ[I...] * sinψ)
     end
 
     return nothing

--- a/src/stokes/StressKernels.jl
+++ b/src/stokes/StressKernels.jl
@@ -824,7 +824,7 @@ end
             setindex!.(τ, τij, I...)
             setindex!.(ε_pl, εij_pl, I...)
             τII[I...] = second_invariant(τij)
-            Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
+            # Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
             η_vep[I...] = 0.5 * τII_ij / εII_ve
         else
             # stress correction @ center
@@ -833,6 +833,7 @@ end
             τII[I...] = τII_ij
         end
 
+        Pr_c[I...] = Pr[I...] + (isinf(K) ? 0.0 : K * dt * λ[I...] * sinψ)
     end
 
     return nothing
@@ -947,7 +948,7 @@ end
             setindex!.(τ, τij, I...)
             setindex!.(ε_pl, εij_pl, I...)
             τII[I...] = GeoParams.second_invariant(τij)
-            Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
+            # Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
             η_vep[I...] = 0.5 * τII_ij / εII_ve
         else
             # stress correction @ center
@@ -956,6 +957,7 @@ end
             τII[I...] = τII_ij
         end
 
+        Pr_c[I...] = Pr[I...] + (isinf(K) ? 0.0 : K * dt * λ[I...] * sinψ)
     end
 
     return nothing


### PR DESCRIPTION
Removes an unnecessary calculation of the pressure with dilatant plasticity that is being calculated even if plasticity is not active. 