### PR TITLE
Add `save_particles`

### DIFF
--- a/src/IO/DataIO.jl
+++ b/src/IO/DataIO.jl
@@ -25,7 +25,7 @@ export checkpointing_jld2, load_checkpoint_jld2
 
 include("VTK.jl")
 
-export VTKDataSeries, append!, save_vtk, save_marker_chain
+export VTKDataSeries, append!, save_vtk, save_marker_chain, save_particles
 
 export metadata
 


### PR DESCRIPTION
Adds `save_particles(particles, pPhases; conversion = 1.0e3, fname::String = "./particles")` to save particles and their phases as VTK. `conversion` is the unit conversion for the particles coordinates.

This PR also adds a convenience wrapper for the marker chain `save_marker_chain(fname::String, chain; conversion = 1.0e3)`