### PR TITLE
fix `η_vep` calc

### DIFF
--- a/src/stokes/StressKernels.jl
+++ b/src/stokes/StressKernels.jl
@@ -823,7 +823,7 @@ end
             τij = dτij .+ τij
             setindex!.(τ, τij, I...)
             setindex!.(ε_pl, εij_pl, I...)
-            τII[I...] = second_invariant(τij)
+            τII[I...] = τII_ij = second_invariant(τij)
             # Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
             η_vep[I...] = 0.5 * τII_ij / εII_ve
         else
@@ -947,7 +947,7 @@ end
             τij = dτij .+ τij
             setindex!.(τ, τij, I...)
             setindex!.(ε_pl, εij_pl, I...)
-            τII[I...] = GeoParams.second_invariant(τij)
+            τII[I...] = τII_ij = GeoParams.second_invariant(τij)
             # Pr_c[I...] = Pr[I...] + K * dt * λ[I...] * sinψ
             η_vep[I...] = 0.5 * τII_ij / εII_ve
         else


### PR DESCRIPTION
There was an issue with the `η_vep` calculation during plasticity leading to a difference when plotting it compared to ` η_eff = @. stokes.τ.II / (2 * stokes.ε.II)`. The issue was only in the `update_stresses_center_vertex_ps!` function. 

Before we used the old `τII_ij` rather than the updated one during yielding. 
Fix:
```julia
τII[I...] = τII_ij = second_invariant(τij)
η_vep[I...] = 0.5 * τII_ij / εII_ve
```