### PR TITLE
soft fail strategy for pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.10'
           - '1.11'
-          - 'pre'
+          # - 'pre'
           # - 'nightly'
         os:
           - ubuntu-latest
@@ -30,16 +31,28 @@ jobs:
           - windows-latest
         arch:
           - x64
+        allow_failure: [false]
         include:
           - os: macOS-latest
             arch: aarch64
             version: '1.10'
+            allow_failure: [false]
           - os: macOS-latest
             arch: aarch64
             version: '1.11'
+            allow_failure: [false]
           - os: macOS-latest
             arch: aarch64
             version: 'pre'
+            allow_failure: true
+          - os: ubuntu-latest
+            arch: x86
+            version: 'pre'
+            allow_failure: true
+          - os: windows-latest
+            arch: x86
+            version: 'pre'
+            allow_failure: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
           - os: macOS-latest
             arch: aarch64
             version: '1.10'
-            allow_failure: [false]
+            allow_failure: false
           - os: macOS-latest
             arch: aarch64
             version: '1.11'
-            allow_failure: [false]
+            allow_failure: false
           - os: macOS-latest
             arch: aarch64
             version: 'pre'


### PR DESCRIPTION
This PR adds an `allow_failure` keyword as described [here](https://discourse.julialang.org/t/ignoring-nightly-failure-for-ci-badge/98028/5) so the CI batch doesn't read failing only due to the pre-release (as suggested by @luraess)