### PR TITLE
Fixes issue related to `ϵ_rel`

### DIFF
--- a/src/stokes/Stokes2D.jl
+++ b/src/stokes/Stokes2D.jl
@@ -46,7 +46,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    err = 1.0
     iter = 0
     err_evo1 = Float64[]
     err_evo2 = Float64[]
@@ -133,7 +133,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end
@@ -184,7 +184,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    1.0
     iter = 0
     err_evo1 = Float64[]
     err_evo2 = Float64[]
@@ -264,7 +264,7 @@ function _solve!(
             end
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end
@@ -321,7 +321,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    1.0
     iter = 0
     err_evo1 = Float64[]
     err_evo2 = Float64[]
@@ -448,7 +448,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end
@@ -518,7 +518,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    1.0
     iter = 0
     err_evo1 = Float64[]
     err_evo2 = Float64[]
@@ -724,7 +724,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end

--- a/src/stokes/Stokes3D.jl
+++ b/src/stokes/Stokes3D.jl
@@ -55,7 +55,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    err = 1.0
     iter = 0
     cont = 0
     err_evo1 = Float64[]
@@ -145,7 +145,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end
@@ -202,7 +202,7 @@ function _solve!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    1.0
     iter = 0
     cont = 0
     err_evo1 = Float64[]
@@ -354,7 +354,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end
@@ -564,7 +564,7 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end

--- a/src/variational_stokes/Stokes2D.jl
+++ b/src/variational_stokes/Stokes2D.jl
@@ -53,7 +53,7 @@ function _solve_VS!(
 
     # errors
     err_it1 = 1.0
-    err = 2 * ϵ_rel
+    err = 1.0
     iter = 0
     err_evo1 = Float64[]
     err_evo2 = Float64[]
@@ -86,8 +86,8 @@ function _solve_VS!(
     compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff; air_phase = air_phase)
     displacement2velocity!(stokes, dt, flow_bcs)
 
-    while iter ≤ iterMax
-        iterMin < iter && ((err / err_it1) < ϵ_rel || err < ϵ_abs) && break
+    while iter ≤ iterMax || (((err / err_it1) > ϵ_rel && err > ϵ_abs) && iter ≤ iterMax)
+        # iterMin < iter && ((err / err_it1) < ϵ_rel || err < ϵ_abs) && break
 
         wtime0 += @elapsed begin
             compute_maxloc!(ητ, η; window = (1, 1))
@@ -249,7 +249,7 @@ function _solve_VS!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 &&((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end

--- a/src/variational_stokes/Stokes3D.jl
+++ b/src/variational_stokes/Stokes3D.jl
@@ -196,7 +196,7 @@ function _solve_VS!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) ≤ ϵ_rel || (err ≤ ϵ_abs))
+        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
             println("Pseudo-transient iterations converged in $iter iterations")
         end
     end


### PR DESCRIPTION
Fixes the issue of printing convergence messages if `ϵ_rel` was lower than `ϵ_abs`.


cc @ChristianSchuler 