### PR TITLE
Bug fix for WENO-5

### DIFF
--- a/miniapps/convection/WENO5/WENO_convection2D.jl
+++ b/miniapps/convection/WENO5/WENO_convection2D.jl
@@ -288,7 +288,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             save(joinpath(figdir, "$(it).png"), fig)
             fig
 
-            save_particles(particles, pPhases; conversion = 1.0e3, fname = joinpath(vtk_dir, "particles_" * lpad("$it", 6, "0")))
+            # save_particles(particles, pPhases; conversion = 1.0e3, fname = joinpath(vtk_dir, "particles_" * lpad("$it", 6, "0")))
         end
         # ------------------------------
 

--- a/src/advection/weno5.jl
+++ b/src/advection/weno5.jl
@@ -116,14 +116,15 @@ end
 end
 
 @inline function _WENO_flux_x(u, nx, weno, i, j, fun::F) where {F}
-    jw, jww = clamp(j - 1, 1, nx), clamp(j - 2, 1, nx)
-    je, jee = clamp(j + 1, 1, nx), clamp(j + 2, 1, nx)
+    iw, iww = clamp(i - 1, 1, nx), clamp(i - 2, 1, nx)
+    ie, iee = clamp(i + 1, 1, nx), clamp(i + 2, 1, nx)
+
     @inbounds begin
-        u1 = u[i, jww]
-        u2 = u[i, jw]
+        u1 = u[iww, j]
+        u2 = u[iw, j]
         u3 = u[i, j]
-        u4 = u[i, je]
-        u5 = u[i, jee]
+        u4 = u[ie, j]
+        u5 = u[iee, j]
     end
     return f = fun(u1, u2, u3, u4, u5, weno)
 end
@@ -137,39 +138,39 @@ end
 end
 
 @inline function _WENO_flux_y(u, ny, weno, i, j, fun::F) where {F}
-    iw, iww = clamp(i - 1, 1, ny), clamp(i - 2, 1, ny)
-    ie, iee = clamp(i + 1, 1, ny), clamp(i + 2, 1, ny)
-
+    jw, jww = clamp(j - 1, 1, ny), clamp(j - 2, 1, ny)
+    je, jee = clamp(j + 1, 1, ny), clamp(j + 2, 1, ny)
     @inbounds begin
-        u1 = u[iww, j]
-        u2 = u[iw, j]
+        u1 = u[i, jww]
+        u2 = u[i, jw]
         u3 = u[i, j]
-        u4 = u[ie, j]
-        u5 = u[iee, j]
+        u4 = u[i, je]
+        u5 = u[i, jee]
     end
     return f = fun(u1, u2, u3, u4, u5, weno)
 end
 
-@inline function weno_rhs(vy, vx, weno, _dx, _dy, nx, ny, i, j)
-    jW, jE = clamp(j - 1, 1, ny), clamp(j + 1, 1, ny)
+
+@inline function weno_rhs(vx, vy, weno, _dx, _dy, nx, ny, i, j)
     iS, iN = clamp(i - 1, 1, nx), clamp(i + 1, 1, nx)
+    jW, jE = clamp(j - 1, 1, ny), clamp(j + 1, 1, ny)
 
     return @inbounds begin
         vx_ij = vx[i, j]
         vy_ij = vy[i, j]
 
-        r = @muladd max(vx_ij, 0) * (weno.fL[i, j] - weno.fL[i, jW]) * _dx +
-            min(vx_ij, 0) * (weno.fR[i, jE] - weno.fR[i, j]) * _dx +
-            max(vy_ij, 0) * (weno.fB[i, j] - weno.fB[iS, j]) * _dy +
-            min(vy_ij, 0) * (weno.fT[iN, j] - weno.fT[i, j]) * _dy
+        r = @muladd max(vx_ij, 0) * (weno.fB[i, j] - weno.fB[iS, j]) * _dx +
+        min(vx_ij, 0) * (weno.fT[iN, j] - weno.fT[i, j]) * _dx +
+        max(vy_ij, 0) * (weno.fL[i, j] - weno.fL[i, jW]) * _dy +
+        min(vy_ij, 0) * (weno.fR[i, jE] - weno.fR[i, j]) * _dy
     end
 end
 
 @parallel_indices inbounds = true (i, j) function weno_f!(u, weno, nx, ny)
-    weno.fL[i, j] = WENO_flux_upwind_x(u, ny, weno, i, j)
-    weno.fR[i, j] = WENO_flux_downwind_x(u, ny, weno, i, j)
-    weno.fB[i, j] = WENO_flux_upwind_y(u, nx, weno, i, j)
-    weno.fT[i, j] = WENO_flux_downwind_y(u, nx, weno, i, j)
+    weno.fB[i, j] = WENO_flux_upwind_x(u, nx, weno, i, j)
+    weno.fT[i, j] = WENO_flux_downwind_x(u, nx, weno, i, j)
+    weno.fL[i, j] = WENO_flux_upwind_y(u, ny, weno, i, j)
+    weno.fR[i, j] = WENO_flux_downwind_y(u, ny, weno, i, j)
     return nothing
 end
 
@@ -188,7 +189,7 @@ Perform the advection step of the Weighted Essentially Non-Oscillatory (WENO) sc
 - `dt`: time step.
 
 # Description
-The function first calculates the fluxes using the WENO scheme. Then it performs three steps of the WENO scheme. Each step involves calculating the right-hand side of the WENO equation and updating the solution `u`. The updating of the solution `u` is done using different combinations of the original solution and the temporary solution `weno.ut`.
+The function approximates the advected fluxes using the WENO scheme and use a strong-stability preserving (SSP) Runge-Kutta method of order 3 for the time integration.
 """
 function WENO_advection!(u, Vxi, weno, di, dt)
     _di = inv.(di)
@@ -219,8 +220,7 @@ end
 end
 
 @parallel_indices (i, j) function weno_step3!(
-        u, weno, Vxi, _di, ni, dt, one_third, two_thirds
-    )
+        u, weno, Vxi, _di, ni, dt, one_third, two_thirds)
     rᵢ = weno_rhs(Vxi..., weno, _di..., ni..., i, j)
     @inbounds u[i, j] = @muladd one_third * u[i, j] + two_thirds * weno.ut[i, j] -
         two_thirds * dt * rᵢ


### PR DESCRIPTION
Hi, 

Diving a bit into the code of the WENO-5, I believe there is a small nasty bug hidden there. 

The problem is the convention of the axes. I believe in my original code, x was the second index (don't ask me why I did that) where x is the first axis in JustRelax.jl. 

I think that was noticed, so the code is a bit confusing sometimes, with `WENO_flux_upwind_x` using `ny` when called for instance, because of that ([here](https://github.com/PTsolvers/JustRelax.jl/blob/8b9aa86890ccafc3b320a6cdf50ac426ba490c40/src/advection/weno5.jl#L168-L174)), which should work, but is a not ideal. So I also wanted to fix that.

The problem is in the [weno_rhs](https://github.com/PTsolvers/JustRelax.jl/blob/8b9aa86890ccafc3b320a6cdf50ac426ba490c40/src/advection/weno5.jl#L153C1-L166C4) function, because `_dx` is used for the y-direction and vice versa. Meaning that when you have nx =! ny or Lx =! Ly, the code is currently using the wrong step for each direction.

So this PR is cleaning the code to follow the same conventions as JustRelax.jl and solving this problem.

Rerunning the convection 2D code, I obtain at t=70 the same thing as before for nx=ny:

<img src="https://github.com/user-attachments/assets/29a7045e-2156-4409-83db-3687c95203c0" width=50% height=20%>
compared to before:
<img src="https://github.com/user-attachments/assets/1c0f2e0d-0e48-4696-9e40-16c3be1cd60e" width=50% height=20%>

Now, changing with nx = 2*ny with this PR:

<img src="https://github.com/user-attachments/assets/0b19ac20-5bcb-40f9-9e9f-b5424fc492c4" width=50% height=20%>

before:
<img src="https://github.com/user-attachments/assets/bb0bc9b4-fbec-4480-aa2f-7594d204a119" width=50% height=20%>





