### PR TITLE
[WIP] Implement conservative WENO-5

### DIFF
--- a/miniapps/convection/WENO5/WENO_convection2D.jl
+++ b/miniapps/convection/WENO5/WENO_convection2D.jl
@@ -95,7 +95,7 @@ end
 ## END OF HELPER FUNCTION ------------------------------------------------------------
 
 ## BEGIN OF MAIN SCRIPT --------------------------------------------------------------
-function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = false)
+function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = false, conservative = true)
 
     # Physical domain ------------------------------------
     ly = 700.0e3            # domain length in y
@@ -261,8 +261,14 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             ),
         )
         T_WENO .= thermal.T[2:(end - 1), :]
-        velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
-        WENO_advection!(T_WENO, (Vx_v, Vy_v), weno, di, dt)
+
+        if conservative == true
+            WENO_advection!(T_WENO, (stokes.V.Vx, stokes.V.Vy), weno, di, dt; conservative = conservative)
+        else
+            velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
+            WENO_advection!(T_WENO, (Vx_v, Vy_v), weno, di, dt; conservative = conservative)
+        end
+
         thermal.T[2:(end - 1), :] .= T_WENO
         # ------------------------------
 
@@ -313,4 +319,4 @@ else
 end
 
 # run main script
-main2D(igg; figdir = figdir, ar = ar, nx = nx, ny = ny);
+main2D(igg; figdir = figdir, ar = ar, nx = nx, ny = ny, conservative = true);

--- a/miniapps/convection/WENO5/WENO_convection2D.jl
+++ b/miniapps/convection/WENO5/WENO_convection2D.jl
@@ -95,7 +95,7 @@ end
 ## END OF HELPER FUNCTION ------------------------------------------------------------
 
 ## BEGIN OF MAIN SCRIPT --------------------------------------------------------------
-function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = false, conservative = true)
+function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", vtk_dir = "vtk2D", do_vtk = false, conservative = true)
 
     # Physical domain ------------------------------------
     ly = 700.0e3            # domain length in y
@@ -262,7 +262,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
         )
         T_WENO .= thermal.T[2:(end - 1), :]
 
-        if conservative == true
+        if conservative
             WENO_advection!(T_WENO, (stokes.V.Vx, stokes.V.Vy), weno, di, dt; conservative = conservative)
         else
             velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
@@ -307,6 +307,7 @@ end
 
 # (Path)/folder where output data and figures are stored
 figdir = "Weno2D"
+vtk_dir = "Weno2D"
 do_vtk = true # save vtk files with particles
 ar = 1 # aspect ratio
 n = 64
@@ -319,4 +320,4 @@ else
 end
 
 # run main script
-main2D(igg; figdir = figdir, ar = ar, nx = nx, ny = ny, conservative = true);
+main2D(igg; figdir = figdir, vtk_dir = vtk_dir, ar = ar, nx = nx, ny = ny, conservative = true);

--- a/src/advection/weno5.jl
+++ b/src/advection/weno5.jl
@@ -155,16 +155,16 @@ end
     iS, iN = clamp(i - 1, 1, nx), clamp(i + 1, 1, nx)
     jW, jE = clamp(j - 1, 1, ny), clamp(j + 1, 1, ny)
 
-    return @inbounds begin
+    return begin
         if conservative == true
             # if staggered grid, we already have velocity on the cell sides, so we can use them directly
             r = @muladd (
-                max(vx[i + 1, j], 0) * weno.fB[i, j] + min(vx[i + 1, j], 0) * weno.fT[iN, j] -
-                    max(vx[i, j], 0) * weno.fB[iS, j] - min(vx[i, j], 0) * weno.fT[i, j]
+                max(vx[iN, j + 1], 0) * weno.fB[i, j] + min(vx[iN, j + 1], 0) * weno.fT[iN, j] -
+                    max(vx[i, j + 1], 0) * weno.fB[iS, j] - min(vx[i, j + 1], 0) * weno.fT[i, j]
             ) * _dx +
                 (
-                max(vy[i, j + 1], 0) * weno.fL[i, j] + min(vy[i, j + 1], 0) * weno.fR[i, jE] -
-                    max(vy[i, j], 0) * weno.fL[i, jW] - min(vy[i, j], 0) * weno.fR[i, j]
+                max(vy[i + 1, jE], 0) * weno.fL[i, j] + min(vy[i + 1, jE], 0) * weno.fR[i, jE] -
+                    max(vy[i + 1, j], 0) * weno.fL[i, jW] - min(vy[i + 1, j], 0) * weno.fR[i, j]
             ) * _dy
         else
             vx_ij = vx[i, j]
@@ -199,12 +199,12 @@ Perform the advection step of the Weighted Essentially Non-Oscillatory (WENO) sc
 - `di`: grid spacing.
 - `ni`: number of grid points.
 - `dt`: time step.
-- `conservative`: if `true`, the scheme is using the conservative form of the advection equation, non-conservative otherwise (default: `true`). `Vxi` must be defined on the sides with `conservative=true` and on the center with `conservative=false`.
+- `conservative`: if `true`, the scheme is using the conservative form of the advection equation, non-conservative otherwise (default: `false`). `Vxi` must be defined on the sides with `conservative=true` and on the center of the stencil with `conservative=false`.
 
 # Description
-The function approximates the advected fluxes using the WENO scheme and use a stronge-stability preserving (SSP) Runge-Kutta method of order 4 for the time integration.
+The function approximates the advected fluxes using the WENO scheme and uses a stronge-stability preserving (SSP) Runge-Kutta method of order 4 for the time integration.
 """
-function WENO_advection!(u, Vxi, weno, di, dt; conservative = true)
+function WENO_advection!(u, Vxi, weno, di, dt; conservative = false)
     _di = inv.(di)
     ni = nx, ny = size(u)
     one_third = inv(3)

--- a/test/test_WENO5.jl
+++ b/test/test_WENO5.jl
@@ -291,7 +291,12 @@ end
             igg
         end
 
-        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular)
+        # test non-conservative approach
+        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative=false)
+        @test passed = iters.err_evo1[end] < 1.0e-4
+
+        # test conservative approach
+        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative=true)
         @test passed = iters.err_evo1[end] < 1.0e-4
 
     end

--- a/test/test_WENO5.jl
+++ b/test/test_WENO5.jl
@@ -264,8 +264,14 @@ function thermal_convection2D(igg; ar = 8, ny = 16, nx = ny * 8, thermal_perturb
 
         # Weno advection
         T_WENO .= @views thermal.T[2:(end - 1), :]
-        velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
-        WENO_advection!(T_WENO, (Vx_v, Vy_v), weno, di, dt)
+
+        if conservative == true
+            WENO_advection!(T_WENO, (stokes.V.Vx, stokes.V.Vy), weno, di, dt; conservative = conservative)
+        else
+            velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
+            WENO_advection!(T_WENO, (Vx_v, Vy_v), weno, di, dt; conservative = conservative)
+        end
+
         @views thermal.T[2:(end - 1), :] .= T_WENO
         # ------------------------------
 

--- a/test/test_WENO5.jl
+++ b/test/test_WENO5.jl
@@ -292,11 +292,11 @@ end
         end
 
         # test non-conservative approach
-        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative=false)
+        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative = false)
         @test passed = iters.err_evo1[end] < 1.0e-4
 
         # test conservative approach
-        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative=true)
+        iters = thermal_convection2D(igg; ar = 8, ny = ny, nx = nx, thermal_perturbation = :circular, conservative = true)
         @test passed = iters.err_evo1[end] < 1.0e-4
 
     end


### PR DESCRIPTION
The current implementation of the WENO-5 advection algorithm is using the non-conservative form of the advection equation (V∂T∂x). We can implement the conservative form (∂(VT)∂x) using directly the velocities on the staggered grid (see for instance [here](https://github.com/yingqiwong/advection)).

Three good reasons to do that:
- No need to interpolate the velocities from the sides to the center anymore
- Makes no assumption on the divergence of V, so will be fully compatible with compressible flow
- Would be fully conservative for the quantity advected

The implementation is a simple addition: using directly the velocities of the staggered grid for the value of the fluxes after using WENO-5 to approximate the advected quantity on the sides .

I have added a boolean kwarg to `WENO_advection!()` to be able to use both the non-conservative and the conservative form, but I believe that the conservative form should be the default. That would be a breaking change, because the input velocities required would be by default the velocities on the sides as opposed to currently velocities on vertices.

I have currently a problem with the boundary conditions, but I think I am mostly there. @albert-de-montserrat, is there a helper function to get only the interior points of for instance `stokes.V.Vx`? Because of the ghost points, I have to add +1 to my indexes currently and it would be nice if it could work by default with velocity fields without ghost points.

Needs https://github.com/PTsolvers/JustRelax.jl/pull/339 to be merged before.
