### PR TITLE
principal stress calculator

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -83,6 +83,9 @@ include("rheology/StressUpdate.jl")
 include("stokes/StressKernels.jl")
 export tensor_invariant!
 
+include("stokes/PrincipalStresses.jl")
+export compute_principal_stresses, compute_principal_stresses!, PrincipalStress
+
 include("stokes/PressureKernels.jl")
 export rotate_stress_particles!
 

--- a/src/ext/CUDA/2D.jl
+++ b/src/ext/CUDA/2D.jl
@@ -143,6 +143,23 @@ function JR2D.update_thermal_coeffs!(
     return nothing
 end
 
+function JR2D.PrincipalStress(::Type{CUDABackend}, ni::NTuple{2})
+    σ1 = fill(SVector(0.0, 0.0), ni...)
+    σ2 = fill(SVector(0.0, 0.0), ni...)
+    σ3 = fill(SVector(0.0, 0.0), 1, 1)
+    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
+end
+
+function JR2D.compute_principal_stresses(backend::Type{CUDABackend}, stokes::JustRelax.StokesArrays)
+    compute_principal_stresses(backend, stokes)
+    return nothing
+end
+
+function JR2D.compute_principal_stresses!(stokes, σ::JustRelax.PrincipalStress{CuArray})
+    compute_principal_stresses!(stokes, σ)
+    return nothing
+end
+
 # Boundary conditions
 function JR2D.flow_bcs!(
         ::CUDABackendTrait, stokes::JustRelax.StokesArrays, bcs::VelocityBoundaryConditions

--- a/src/ext/CUDA/2D.jl
+++ b/src/ext/CUDA/2D.jl
@@ -144,9 +144,9 @@ function JR2D.update_thermal_coeffs!(
 end
 
 function JR2D.PrincipalStress(::Type{CUDABackend}, ni::NTuple{2})
-    σ1 = fill(SVector(0.0, 0.0), ni...)
-    σ2 = fill(SVector(0.0, 0.0), ni...)
-    σ3 = fill(SVector(0.0, 0.0), 1, 1)
+    σ1 = CUDA.fill(SVector(0.0, 0.0), ni...)
+    σ2 = CUDA.fill(SVector(0.0, 0.0), ni...)
+    σ3 = CUDA.fill(SVector(0.0, 0.0), 1, 1)
     return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
 end
 

--- a/src/ext/CUDA/2D.jl
+++ b/src/ext/CUDA/2D.jl
@@ -143,20 +143,20 @@ function JR2D.update_thermal_coeffs!(
     return nothing
 end
 
-function JR2D.PrincipalStress(::Type{CUDABackend}, ni::NTuple{2})
-    σ1 = CUDA.fill(SVector(0.0, 0.0), ni...)
-    σ2 = CUDA.fill(SVector(0.0, 0.0), ni...)
-    σ3 = CUDA.fill(SVector(0.0, 0.0), 1, 1)
-    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
+function JR2D.PrincipalStress(backend::Type{CUDABackend}, ni::NTuple{N, Integer}) where {N}
+    return PrincipalStress(ni)
 end
 
 function JR2D.compute_principal_stresses(backend::Type{CUDABackend}, stokes::JustRelax.StokesArrays)
-    compute_principal_stresses(backend, stokes)
-    return nothing
+    ni = size(stokes.P)
+    σ = JR2D.PrincipalStress(backend, ni)
+    compute_principal_stresses!(stokes, σ)
+    return σ
 end
 
-function JR2D.compute_principal_stresses!(stokes, σ::JustRelax.PrincipalStress{CuArray})
-    compute_principal_stresses!(stokes, σ)
+function JR2D.compute_principal_stresses!(stokes, σ::JustRelax.PrincipalStress{<:CuArray})
+    ni = size(stokes.P)
+    @parallel (@idx ni) principal_stresses_eigen!(σ, @stress_center(stokes)...)
     return nothing
 end
 

--- a/src/ext/CUDA/3D.jl
+++ b/src/ext/CUDA/3D.jl
@@ -156,9 +156,9 @@ function JR3D.update_thermal_coeffs!(
 end
 
 function JR3D.PrincipalStress(::Type{CUDABackend}, ni::NTuple{3})
-    σ1 = fill(SVector(0.0, 0.0, 0.0), ni...)
-    σ2 = fill(SVector(0.0, 0.0, 0.0), ni...)
-    σ3 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ1 = CUDA.fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ2 = CUDA.fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ3 = CUDA.fill(SVector(0.0, 0.0, 0.0), ni...)
     return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
 end
 

--- a/src/ext/CUDA/3D.jl
+++ b/src/ext/CUDA/3D.jl
@@ -155,6 +155,23 @@ function JR3D.update_thermal_coeffs!(
     return nothing
 end
 
+function JR3D.PrincipalStress(::Type{CUDABackend}, ni::NTuple{3})
+    σ1 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ2 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ3 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
+end
+
+function JR3D.compute_principal_stresses(backend::Type{CUDABackend}, stokes::JustRelax.StokesArrays)
+    compute_principal_stresses(backend, stokes)
+    return nothing
+end
+
+function JR3D.compute_principal_stresses!(stokes, σ::JustRelax.PrincipalStress{CuArray})
+    compute_principal_stresses!(stokes, σ)
+    return nothing
+end
+
 # Boundary conditions
 function JR3D.flow_bcs!(
         ::CUDABackendTrait, stokes::JustRelax.StokesArrays, bcs::VelocityBoundaryConditions

--- a/src/stokes/PrincipalStresses.jl
+++ b/src/stokes/PrincipalStresses.jl
@@ -14,9 +14,9 @@ end
 @parallel_indices (I...) function principal_stresses_eigen!(σ::JustRelax.PrincipalStress, τ_xx, τ_yy, τ_xy)
 
     # Construct the stress tensor
-    τ_11 = τ_xx[I...]
-    τ_22 = τ_yy[I...]
-    τ_12 = τ_xy[I...]
+    τ_11 = @inbounds τ_xx[I...]
+    τ_22 = @inbounds τ_yy[I...]
+    τ_12 = @inbounds τ_xy[I...]
 
     a = (τ_11 + τ_22) / 2
     b = √((τ_11 - τ_22)^2 / 2 + τ_12^2)
@@ -31,10 +31,9 @@ end
     e2 = SA[-sinθ, cosθ]
 
     Base.@nexprs 2 i -> begin
-        σ.σ1[i, I...] = σ1 * e1[i]
-        σ.σ2[i, I...] = σ2 * e2[i]
+        @inbounds σ.σ1[i, I...] = σ1 * e1[i]
+        @inbounds σ.σ2[i, I...] = σ2 * e2[i]
     end
-
 
     return nothing
 end
@@ -42,9 +41,9 @@ end
 @parallel_indices (I...) function principal_stresses_eigen!(σ::JustRelax.PrincipalStress, τ_xx, τ_yy, τ_zz, τ_yz, τ_xz, τ_xy)
 
     # Construct the stress tensor
-    τ_12 = τ_xy[I...]
-    τ_13 = τ_xz[I...]
-    τ_23 = τ_yz[I...]
+    τ_12 = @inbounds τ_xy[I...]
+    τ_13 = @inbounds τ_xz[I...]
+    τ_23 = @inbounds τ_yz[I...]
     τ = @SMatrix [
         τ_xx[I...] τ_12 τ_13
         τ_12 τ_yy[I...] τ_23
@@ -54,9 +53,9 @@ end
     σ1, σ2, σ3 = hessenberg_eigen_3x3(A)
 
     Base.@nexprs 3 i -> begin
-        σ.σ1[i, I...] = σ1[i]
-        σ.σ2[i, I...] = σ2[i]
-        σ.σ3[i, I...] = σ3[i]
+        @inbounds σ.σ1[i, I...] = σ1[i]
+        @inbounds σ.σ2[i, I...] = σ2[i]
+        @inbounds σ.σ3[i, I...] = σ3[i]
     end
 
     return nothing

--- a/src/stokes/PrincipalStresses.jl
+++ b/src/stokes/PrincipalStresses.jl
@@ -1,11 +1,11 @@
-function PrincipalStress(::B, ni::NTuple{2}) where B
+function PrincipalStress(::B, ni::NTuple{2}) where {B}
     σ1 = fill(SVector(0.0, 0.0), ni...)
     σ2 = fill(SVector(0.0, 0.0), ni...)
     σ3 = fill(SVector(0.0, 0.0), 1, 1)
     return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
 end
 
-function PrincipalStress(::B, ni::NTuple{3}) where B
+function PrincipalStress(::B, ni::NTuple{3}) where {B}
     σ1 = fill(SVector(0.0, 0.0, 0.0), ni...)
     σ2 = fill(SVector(0.0, 0.0, 0.0), ni...)
     σ3 = fill(SVector(0.0, 0.0, 0.0), ni...)
@@ -33,7 +33,7 @@ end
         τ_xx[I...] τ_12
         τ_12 τ_yy[I...]
     ]
-            
+
     # Compute the eigenvalues (principal stresses)
     vals, vecs = eigen(τ)
     # Compute the principal directions (eigenvectors)
@@ -55,7 +55,7 @@ end
         τ_12 τ_yy[I...] τ_23
         τ_13 τ_23 τ_zz[I...]
     ]
-            
+
     # Compute the eigenvalues (principal stresses)
     vals, vecs = eigen(τ)
     # Compute the principal directions (eigenvectors)

--- a/src/stokes/PrincipalStresses.jl
+++ b/src/stokes/PrincipalStresses.jl
@@ -1,0 +1,68 @@
+function PrincipalStress(::B, ni::NTuple{2}) where B
+    σ1 = fill(SVector(0.0, 0.0), ni...)
+    σ2 = fill(SVector(0.0, 0.0), ni...)
+    σ3 = fill(SVector(0.0, 0.0), 1, 1)
+    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
+end
+
+function PrincipalStress(::B, ni::NTuple{3}) where B
+    σ1 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ2 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    σ3 = fill(SVector(0.0, 0.0, 0.0), ni...)
+    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
+end
+
+function compute_principal_stresses(backend, stokes::JustRelax.StokesArrays)
+    ni = size(stokes.P)
+    σ = PrincipalStress(backend, ni)
+    @parallel (@idx ni) principal_stresses_eigen!(σ, @stress_center(stokes)...)
+    return σ
+end
+
+function compute_principal_stresses!(stokes, σ::JustRelax.PrincipalStress)
+    ni = size(stokes.P)
+    @parallel (@idx ni) principal_stresses_eigen!(σ, @stress_center(stokes)...)
+    return nothing
+end
+
+@parallel_indices (I...) function principal_stresses_eigen!(σ::JustRelax.PrincipalStress, τ_xx, τ_yy, τ_xy)
+
+    # Construct the stress tensor
+    τ_12 = τ_xy[I...]
+    τ = @SMatrix [
+        τ_xx[I...] τ_12
+        τ_12 τ_yy[I...]
+    ]
+            
+    # Compute the eigenvalues (principal stresses)
+    vals, vecs = eigen(τ)
+    # Compute the principal directions (eigenvectors)
+    i2, i1 = sortperm(vals)
+    σ.σ1[I...] = SA[vals[i1] * vecs[1, i1], vals[i1] * vecs[2, i1]]
+    σ.σ2[I...] = SA[vals[i2] * vecs[1, i2], vals[i2] * vecs[2, i2]]
+
+    return nothing
+end
+
+@parallel_indices (I...) function principal_stresses_eigen!(σ::JustRelax.PrincipalStress, τ_xx, τ_yy, τ_zz, τ_yz, τ_xz, τ_xy)
+
+    # Construct the stress tensor
+    τ_12 = τ_xy[I...]
+    τ_13 = τ_xz[I...]
+    τ_23 = τ_yz[I...]
+    τ = @SMatrix [
+        τ_xx[I...] τ_12 τ_13
+        τ_12 τ_yy[I...] τ_23
+        τ_13 τ_23 τ_zz[I...]
+    ]
+            
+    # Compute the eigenvalues (principal stresses)
+    vals, vecs = eigen(τ)
+    # Compute the principal directions (eigenvectors)
+    i3, i2, i1 = sortperm(vals)
+    σ.σ1[I...] = SA[vals[i1] * vecs[1, i1], vals[i1] * vecs[2, i1], vals[i1] * vecs[3, i1]]
+    σ.σ2[I...] = SA[vals[i2] * vecs[1, i2], vals[i2] * vecs[2, i2], vals[i2] * vecs[3, i2]]
+    σ.σ3[I...] = SA[vals[i3] * vecs[1, i3], vals[i3] * vecs[2, i3], vals[i3] * vecs[3, i3]]
+
+    return nothing
+end

--- a/src/stokes/PrincipalStresses.jl
+++ b/src/stokes/PrincipalStresses.jl
@@ -1,17 +1,3 @@
-function PrincipalStress(::B, ni::NTuple{2}) where {B}
-    σ1 = fill(SVector(0.0, 0.0), ni...)
-    σ2 = fill(SVector(0.0, 0.0), ni...)
-    σ3 = fill(SVector(0.0, 0.0), 1, 1)
-    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
-end
-
-function PrincipalStress(::B, ni::NTuple{3}) where {B}
-    σ1 = fill(SVector(0.0, 0.0, 0.0), ni...)
-    σ2 = fill(SVector(0.0, 0.0, 0.0), ni...)
-    σ3 = fill(SVector(0.0, 0.0, 0.0), ni...)
-    return JustRelax.PrincipalStress{typeof(σ1)}(σ1, σ2, σ3)
-end
-
 function compute_principal_stresses(backend, stokes::JustRelax.StokesArrays)
     ni = size(stokes.P)
     σ = PrincipalStress(backend, ni)
@@ -38,8 +24,13 @@ end
     vals, vecs = eigen(τ)
     # Compute the principal directions (eigenvectors)
     i2, i1 = sortperm(vals)
-    σ.σ1[I...] = SA[vals[i1] * vecs[1, i1], vals[i1] * vecs[2, i1]]
-    σ.σ2[I...] = SA[vals[i2] * vecs[1, i2], vals[i2] * vecs[2, i2]]
+    σ1 = SA[vals[i1] * vecs[1, i1], vals[i1] * vecs[2, i1]]
+    σ2 = SA[vals[i2] * vecs[1, i2], vals[i2] * vecs[2, i2]]
+
+    Base.@nexprs 2 i -> begin
+        σ.σ1[i, I...] = σ1[i]
+        σ.σ2[i, I...] = σ2[i]
+    end
 
     return nothing
 end
@@ -56,13 +47,92 @@ end
         τ_13 τ_23 τ_zz[I...]
     ]
 
-    # Compute the eigenvalues (principal stresses)
-    vals, vecs = eigen(τ)
-    # Compute the principal directions (eigenvectors)
-    i3, i2, i1 = sortperm(vals)
-    σ.σ1[I...] = SA[vals[i1] * vecs[1, i1], vals[i1] * vecs[2, i1], vals[i1] * vecs[3, i1]]
-    σ.σ2[I...] = SA[vals[i2] * vecs[1, i2], vals[i2] * vecs[2, i2], vals[i2] * vecs[3, i2]]
-    σ.σ3[I...] = SA[vals[i3] * vecs[1, i3], vals[i3] * vecs[2, i3], vals[i3] * vecs[3, i3]]
+    σ1, σ2, σ3 = hessenberg_eigen_3x3(A)
+
+    Base.@nexprs 3 i -> begin
+        σ.σ1[i, I...] = σ1[i]
+        σ.σ2[i, I...] = σ2[i]
+        σ.σ3[i, I...] = σ3[i]
+    end
 
     return nothing
+end
+
+# Hessenberg method with spectral shift for 3x3 matrices 
+
+function hessenberg_eigen_3x3(A; tol = 1e-10, max_iter = 50)
+    H, Q_hess = hessenberg_3x3(A)
+    I_SA = SA[1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0] 
+    V = I_SA
+    for _ in 1:max_iter
+        λ = H[end, end] * I_SA
+        Q, R = qr(H - λ)
+        H = R * Q + λ
+        V = V * Q
+        check_eigen_convergence(H; tol=tol) && break
+    end
+    # eigenvectors
+    eᵢ = Q_hess * V
+    # eigenvalues
+    σ = diag(H)
+    perms = reverse(sortperm(σ))
+    σ = σ[perms]
+
+    Base.@nexprs 3 j -> σ_j = begin
+        permⱼ = perms[j]
+        x = Base.@ntuple 3 i -> begin
+            σ[j] * eᵢ[i, permⱼ]
+        end 
+        SVector(x...)
+    end
+    return σ_1, σ_2, σ_3
+end
+
+function check_eigen_convergence(H; tol = 1e-10)
+    # If not converged, check if all off-diagonal elements are small enough
+    converged = false
+    for i in 1:3, j in 1:3
+        i == j && continue
+        converged = abs(H[i, j]) < tol
+        converged || return false
+    end
+    return true
+end
+
+function hessenberg_3x3(A)
+
+    # Extract vector to zero out a31
+    x = SA[
+        A[2, 1]
+        A[3, 1]
+    ]
+
+    # Compute Householder vector
+    α = norm(x)
+    I2 = SA[
+        1.0 0.0
+        0.0 1.0
+    ]
+    Q_sub = if iszero(α)
+        I2
+    else
+        e1 = SA[1.0, 0.0]
+        v = x + sign(x[1]) * α * e1
+        v = v / norm(v)
+
+        # Householder matrix for 2x2 block
+        I2 .- 2 * (v * v')
+    end
+
+    # Build full Q (3x3)
+    Q = SA[
+        1.0 0.0 0.0
+        0.0 Q_sub[1, 1] Q_sub[1, 2]
+        0.0 Q_sub[2, 1] Q_sub[2, 2]
+    ]  
+
+    # Compute Hessenberg form
+    H = (Q' * A) * Q
+    
+    return H, Q
 end

--- a/src/types/constructors/stokes.jl
+++ b/src/types/constructors/stokes.jl
@@ -61,6 +61,27 @@ function Viscosity(ni::NTuple{N, Integer}) where {N}
     return JustRelax.Viscosity(η, η_vep, ητ)
 end
 
+
+# Principal stress
+
+function PrincipalStress(::Type{CPUBackend}, ni::NTuple{N, Integer}) where {N}
+    return PrincipalStress(ni)
+end
+
+function PrincipalStress(ni::NTuple{2, Integer})
+    σ1 = @zeros(2, ni...)
+    σ2 = @zeros(2, ni...)
+    σ3 = @zeros(2, 1, 1)
+    return JustRelax.PrincipalStress(σ1, σ2, σ3)
+end
+
+function PrincipalStress(ni::NTuple{3, Integer})
+    σ1 = @zeros(3, ni...)
+    σ2 = @zeros(3, ni...)
+    σ3 = @zeros(3, ni...)
+    return JustRelax.PrincipalStress(σ1, σ2, σ3)
+end
+
 ## SymmetricTensor type
 
 function SymmetricTensor(nx::Integer, ny::Integer)

--- a/src/types/stokes.jl
+++ b/src/types/stokes.jl
@@ -136,6 +136,13 @@ function Residual(::Number, ::Number, ::Number)
     throw(ArgumentError("Residual dimensions must be given as integers"))
 end
 
+## PrincipalStress type
+struct PrincipalStress{T}
+    σ1::T
+    σ2::T
+    σ3::T
+end
+
 ## StokesArrays type
 
 struct StokesArrays{A, B, C, D, E, F, T}

--- a/src/types/stokes.jl
+++ b/src/types/stokes.jl
@@ -141,7 +141,11 @@ struct PrincipalStress{T}
     σ1::T
     σ2::T
     σ3::T
+
+    PrincipalStress(σ1::T, σ2::T, σ3::T) where {T<:AbstractArray} = new{T}(σ1, σ2, σ3)
 end
+
+Adapt.@adapt_structure PrincipalStress
 
 ## StokesArrays type
 

--- a/src/types/stokes.jl
+++ b/src/types/stokes.jl
@@ -142,7 +142,7 @@ struct PrincipalStress{T}
     σ2::T
     σ3::T
 
-    PrincipalStress(σ1::T, σ2::T, σ3::T) where {T<:AbstractArray} = new{T}(σ1, σ2, σ3)
+    PrincipalStress(σ1::T, σ2::T, σ3::T) where {T <: AbstractArray} = new{T}(σ1, σ2, σ3)
 end
 
 Adapt.@adapt_structure PrincipalStress


### PR DESCRIPTION
Adds a principal stress calculator, with an out-of-place method
```julia
compute_principal_stresses(backend, stokes::JustRelax.StokesArrays)
```
and an in-place method
```julia
compute_principal_stresses!(stokes::JustRelax.StokesArrays, σ::JustRelax.PrincipalStress)
```

Note for the future: turns out `LinearAlgebra.eigen` does not work on CUDA. So for 2D `eigen` is replaced by the analytical solution, while in 3D I implemented a Hessenberg QR decomposition with shift. 

And example of usage and visualization:

```julia
σ = PrincipalStress(backend, ni)
compute_principal_stresses!(stokes, σ)
σ1 = σ.σ1

σ1_x = σ1[1, :, :] ./ 2
σ1_y = σ1[2, :, :] ./ 2
nt = 4 # plotting stride

fig = Figure(size = (900, 900), title = "t = $t")
ax = Axis(fig[1, 1], aspect = 1)
heatmap!(ax, xci./1e3..., Array(stokes.τ.II), colormap = :bamako)
arrows!(
    ax,
    xci[1][1:nt:end] ./ 1e3,
    xci[2][1:nt:end] ./ 1e3,
    σ1_x[1:nt:end, 1:nt:end],
    σ1_y[1:nt:end, 1:nt:end],
    arrowsize  = 0,
    lengthscale=1e-6,
    color= :red,
    linewidth = 3
)
arrows!(
    ax,
    xci[1][1:nt:end] ./ 1e3,
    xci[2][1:nt:end] ./ 1e3,
    -σ1_x[1:nt:end, 1:nt:end],
    -σ1_y[1:nt:end, 1:nt:end],
    arrowsize  = 0,
    lengthscale=1e-6,
    color= :red,
    linewidth = 3
)
```
Should produce:
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/8f6db076-2ec1-43c5-81b5-f9f4c6cbb1be" />
