### PR TITLE
Add new `ϵ_nonlinear` keyword to the Stokes solvers

### DIFF
--- a/src/stokes/Stokes2D.jl
+++ b/src/stokes/Stokes2D.jl
@@ -489,6 +489,7 @@ function _solve!(
         args,
         dt,
         igg::IGG;
+        ϵ_nonlinear = Inf,
         strain_increment = false,
         viscosity_cutoff = (-Inf, Inf),
         viscosity_relaxation = 1.0e-2,
@@ -545,14 +546,13 @@ function _solve!(
         Aij .= 0.0
     end
 
-
     # compute buoyancy forces and viscosity
     compute_ρg!(ρg, phase_ratios, rheology, args)
     compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
     displacement2velocity!(stokes, dt, flow_bcs)
 
     while iter ≤ iterMax
-        iterMin < iter && ((err / err_it1) < ϵ_rel || err < ϵ_abs) && break
+        # iterMin < iter && ((err / err_it1) < ϵ_rel && err < ϵ_abs) && break
 
         wtime0 += @elapsed begin
             compute_maxloc!(ητ, η; window = (1, 1))
@@ -595,15 +595,16 @@ function _solve!(
                 )
             end
 
-            update_viscosity!(
-                stokes,
-                phase_ratios,
-                args,
-                rheology,
-                viscosity_cutoff;
-                relaxation = viscosity_relaxation,
-            )
-            # end
+            if err ≤ ϵ_nonlinear
+                update_viscosity!(
+                    stokes,
+                    phase_ratios,
+                    args,
+                    rheology,
+                    viscosity_cutoff;
+                    relaxation = viscosity_relaxation,
+                )
+            end
 
             if strain_increment
                 @parallel (@idx ni .+ 1) update_stresses_center_vertex_ps!(
@@ -630,7 +631,8 @@ function _solve!(
                     phase_ratios.vertex,
                     phase_ratios.xy,
                     phase_ratios.yz,
-                    phase_ratios.xz
+                    phase_ratios.xz,
+                    err ≤ ϵ_nonlinear,
                 )
             else
                 @parallel (@idx ni .+ 1) update_stresses_center_vertex_ps!(
@@ -654,9 +656,9 @@ function _solve!(
                     rheology,
                     phase_ratios.center,
                     phase_ratios.vertex,
+                    err ≤ ϵ_nonlinear,
                 )
             end
-
             update_halo!(stokes.τ.xy)
 
             @hide_communication b_width begin # communication/computation overlap
@@ -709,7 +711,6 @@ function _solve!(
             push!(err_evo2, iter)
             err_it1 = maximum_mpi([norm_Rx[1], norm_Ry[1], norm_∇V[1]])
             rel_err = err / err_it1
-
             if igg.me == 0 #&& ((verbose && err > ϵ_rel) || iter == iterMax)
                 @printf(
                     "Total steps = %d, abs_err = %1.3e , rel_err = %1.3e [norm_Rx=%1.3e, norm_Ry=%1.3e, norm_∇V=%1.3e] \n",
@@ -724,8 +725,9 @@ function _solve!(
             isnan(err) && error("NaN(s)")
         end
 
-        if igg.me == 0 && ((err / err_it1) < ϵ_rel || (err < ϵ_abs))
+        if igg.me == 0 && iterMin < iter && ((err / err_it1) < ϵ_rel && err < ϵ_abs)
             println("Pseudo-transient iterations converged in $iter iterations")
+            break
         end
     end
 

--- a/src/stokes/Stokes3D.jl
+++ b/src/stokes/Stokes3D.jl
@@ -397,6 +397,7 @@ function _solve!(
         args,
         dt,
         igg::IGG;
+        ϵ_nonlinear = Inf,
         iterMax = 10.0e3,
         nout = 500,
         b_width = (4, 4, 4),
@@ -476,15 +477,16 @@ function _solve!(
             update_ρg!(ρg, phase_ratios, rheology, args)
 
             # Update viscosity
-            update_viscosity!(
-                stokes,
-                phase_ratios,
-                args,
-                rheology,
-                viscosity_cutoff;
-                relaxation = viscosity_relaxation,
-            )
-            # update_stress!(stokes, θ, λ, phase_ratios, rheology, dt, pt_stokes.θ_dτ)
+            if ϵ_nonlinear
+                update_viscosity!(
+                    stokes,
+                    phase_ratios,
+                    args,
+                    rheology,
+                    viscosity_cutoff;
+                    relaxation = viscosity_relaxation,
+                )
+            end
 
             @parallel (@idx ni .+ 1) update_stresses_center_vertex_ps!(
                 @strain(stokes),
@@ -510,6 +512,7 @@ function _solve!(
                 phase_ratios.xy,
                 phase_ratios.yz,
                 phase_ratios.xz,
+                err < ϵ_nonlinear
             )
             update_halo!(stokes.τ.yz)
             update_halo!(stokes.τ.xz)

--- a/src/stokes/StressKernels.jl
+++ b/src/stokes/StressKernels.jl
@@ -606,6 +606,7 @@ end
         phase_xy,
         phase_yz,
         phase_xz,
+        do_plasticity,
     )
     τyzv, τxzv, τxyv = τshear_v
     τyzv_old, τxzv_old, τxyv_old = τshear_ov
@@ -664,7 +665,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if do_plasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[1][I...] =
                 (1.0 - relλ) * λv[1][I...] +
@@ -727,7 +728,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if do_plasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[2][I...] =
                 (1.0 - relλ) * λv[2][I...] +
@@ -791,7 +792,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if do_plasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[3][I...] =
                 (1.0 - relλ) * λv[3][I...] +
@@ -828,7 +829,7 @@ end
         # yield function @ center
         F = τII_ij - C * cosϕ - Pr[I...] * sinϕ
 
-        if is_pl && !iszero(τII_ij) && F > 0
+        if do_plasticity && is_pl && !iszero(τII_ij) && F > 0
             # stress correction @ center
             λ[I...] =
                 (1.0 - relλ) * λ[I...] +
@@ -877,6 +878,7 @@ end
         rheology,
         phase_center,
         phase_vertex,
+        do_plasticity
     )
 
     τxyv = τshear_v[1]
@@ -914,7 +916,7 @@ end
     # yield function @ center
     Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
 
-    @inbounds if is_pl && !iszero(τIIv_ij)  && Fv > 0
+    @inbounds if do_plasticity && is_pl && !iszero(τIIv_ij)  && Fv > 0
         # stress correction @ vertex
         λv[I...] =
             (1.0 - relλ) * λv[I...] +
@@ -949,8 +951,12 @@ end
         τII_ij = GeoParams.second_invariant(dτij .+ τij)
         # yield function @ center
         F = @inbounds  τII_ij - C * cosϕ - Pr[I...] * sinϕ
-
-        τII_ij = @inbounds if is_pl && !iszero(τII_ij) && F > 0
+        # if F > 0
+        #     @show do_plasticity
+        #     println("POTATO")
+        #     error()
+        # end
+        τII_ij = @inbounds if do_plasticity && is_pl && !iszero(τII_ij) && F > 0
             # stress correction @ center
             λ[I...] =
                 (1.0 - relλ) * λ[I...] +
@@ -1008,6 +1014,7 @@ end
         phase_xy,
         phase_yz,
         phase_xz,
+        do_plasticity
     )
     τxyv = τshear_v[1]
     τxyv_old = τshear_ov[1]
@@ -1047,7 +1054,7 @@ end
 
     # yield function @ center
     Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-    if is_pl && !iszero(τIIv_ij) && Fv > 0
+    if do_plasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
         # stress correction @ vertex
         λv[I...] =
             (1.0 - relλ) * λv[I...] +
@@ -1084,7 +1091,7 @@ end
         # yield function @ center
         F = τII_ij - C * cosϕ - Pr[I...] * sinϕ
 
-        τII_ij = if is_pl && !iszero(τII_ij) && F > 0
+        τII_ij = if do_plasticity && is_pl && !iszero(τII_ij) && F > 0
             # stress correction @ center
             λ[I...] =
                 (1.0 - relλ) * λ[I...] +
@@ -1112,7 +1119,6 @@ end
 
     return nothing
 end
-
 
 Base.@propagate_inbounds @inline function clamped_indices(ni::NTuple{2, Integer}, i, j)
     nx, ny = ni

--- a/src/variational_stokes/Stokes2D.jl
+++ b/src/variational_stokes/Stokes2D.jl
@@ -23,6 +23,7 @@ function _solve_VS!(
         args,
         dt,
         igg::IGG;
+        ϵ_nonlinear = Inf,
         strain_increment = false,
         air_phase::Integer = 0,
         viscosity_cutoff = (-Inf, Inf),
@@ -130,15 +131,17 @@ function _solve_VS!(
                 )
             end
 
-            update_viscosity!(
-                stokes,
-                phase_ratios,
-                args,
-                rheology,
-                viscosity_cutoff;
-                air_phase = air_phase,
-                relaxation = viscosity_relaxation,
-            )
+            if err ≤ ϵ_nonlinear
+                update_viscosity!(
+                    stokes,
+                    phase_ratios,
+                    args,
+                    rheology,
+                    viscosity_cutoff;
+                    air_phase = air_phase,
+                    relaxation = viscosity_relaxation,
+                )
+            end
 
             if strain_increment
                 @parallel (@idx ni .+ 1) update_stresses_center_vertex!(
@@ -164,6 +167,7 @@ function _solve_VS!(
                     phase_ratios.center,
                     phase_ratios.vertex,
                     ϕ,
+                    err ≤ ϵ_nonlinear
                 )
             else
                 @parallel (@idx ni .+ 1) update_stresses_center_vertex!(
@@ -188,6 +192,7 @@ function _solve_VS!(
                     phase_ratios.center,
                     phase_ratios.vertex,
                     ϕ,
+                    err ≤ ϵ_nonlinear,
                 )
             end
 

--- a/src/variational_stokes/StressKernels.jl
+++ b/src/variational_stokes/StressKernels.jl
@@ -21,6 +21,7 @@
         phase_center,
         phase_vertex,
         ϕ::JustRelax.RockRatio,
+        doplasticity
     ) where {T}
     τxyv = τshear_v[1]
     τxyv_old = τshear_ov[1]
@@ -61,7 +62,7 @@
         # yield function @ center
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
 
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if doplasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[I...] =
                 @muladd (1.0 - relλ) * λv[I...] +
@@ -101,7 +102,7 @@
             # yield function @ center
             F = τII_ij - C * cosϕ - Pr[I...] * sinϕ
 
-            τII_ij = if is_pl && !iszero(τII_ij) && F > 0
+            τII_ij = if doplasticity && is_pl && !iszero(τII_ij) && F > 0
                 # stress correction @ center
                 λ[I...] =
                     @muladd (1.0 - relλ) * λ[I...] +
@@ -165,6 +166,7 @@ end
         phase_yz,
         phase_xz,
         ϕ::JustRelax.RockRatio,
+        doplasticity
     )
     τyzv, τxzv, τxyv = τshear_v
     τyzv_old, τxzv_old, τxyv_old = τshear_ov
@@ -223,7 +225,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if doplasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[1][I...] =
                 (1.0 - relλ) * λv[1][I...] +
@@ -286,7 +288,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if doplasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[2][I...] =
                 (1.0 - relλ) * λv[2][I...] +
@@ -350,7 +352,7 @@ end
 
         # yield function @ vertex
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if doplasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[3][I...] =
                 (1.0 - relλ) * λv[3][I...] +
@@ -387,7 +389,7 @@ end
         # yield function @ center
         F = τII_ij - C * cosϕ - Pr[I...] * sinϕ
 
-        if is_pl && !iszero(τII_ij) && F > 0
+        if doplasticity && is_pl && !iszero(τII_ij) && F > 0
             # stress correction @ center
             λ[I...] =
                 (1.0 - relλ) * λ[I...] +
@@ -440,6 +442,7 @@ end
         phase_center,
         phase_vertex,
         ϕ::JustRelax.RockRatio,
+        doplasticity
     ) where {T}
     τxyv = τshear_v[1]
     τxyv_old = τshear_ov[1]
@@ -482,7 +485,7 @@ end
 
         # yield function @ center
         Fv = τIIv_ij - Cv * cosϕv - Pv_ij * sinϕv
-        if is_pl && !iszero(τIIv_ij) && Fv > 0
+        if doplasticity && is_pl && !iszero(τIIv_ij) && Fv > 0
             # stress correction @ vertex
             λv[I...] =
                 (1.0 - relλ) * λv[I...] +
@@ -525,7 +528,7 @@ end
             # yield function @ center
             F = τII_ij - C * cosϕ - Pr[I...] * sinϕ
 
-            τII_ij = if is_pl && !iszero(τII_ij) && F > 0
+            τII_ij = if doplasticity && is_pl && !iszero(τII_ij) && F > 0
                 # stress correction @ center
                 λ[I...] =
                     (1.0 - relλ) * λ[I...] +


### PR DESCRIPTION
Adds a new keyword `ϵ_nonlinear`  (`Inf` by default) to the Stokes solvers. Non linearities (viscosity and plastic corrections) are not considered while the global error is `err > ϵ_nonlinear`. Seems to help convergence in highly complex models.
