### PR TITLE
Fix 2nd inv calculation routines

### DIFF
--- a/src/ext/AMDGPU/2D.jl
+++ b/src/ext/AMDGPU/2D.jl
@@ -223,8 +223,8 @@ function compute_viscosity!(η, ν, εII::ROCArray, args, rheology, cutoff)
 end
 
 ## Stress
-function JR2D.tensor_invariant!(::AMDGPUBackendTrait, A::JustRelax.SymmetricTensor)
-    return _tensor_invariant!(A)
+function JR2D.tensor_invariant!(::AMDGPUBackendTrait, A::JustRelax.SymmetricTensor, Kb)
+    return _tensor_invariant!(A, Kb)
 end
 
 ## Buoyancy forces

--- a/src/ext/AMDGPU/3D.jl
+++ b/src/ext/AMDGPU/3D.jl
@@ -222,8 +222,8 @@ function compute_viscosity!(η, ν, εII::ROCArray, args, rheology, cutoff)
 end
 
 ## Stress
-function JR3D.tensor_invariant!(::AMDGPUBackendTrait, A::JustRelax.SymmetricTensor)
-    return _tensor_invariant!(A)
+function JR3D.tensor_invariant!(::AMDGPUBackendTrait, A::JustRelax.SymmetricTensor, Kb)
+    return _tensor_invariant!(A, Kb)
 end
 
 ## Buoyancy forces

--- a/src/ext/CUDA/2D.jl
+++ b/src/ext/CUDA/2D.jl
@@ -231,8 +231,8 @@ function compute_viscosity!(η, ν, εII::CuArray, args, rheology, cutoff)
 end
 
 ## Stress
-function JR2D.tensor_invariant!(::CUDABackendTrait, A::JustRelax.SymmetricTensor)
-    return _tensor_invariant!(A)
+function JR2D.tensor_invariant!(::CUDABackendTrait, A::JustRelax.SymmetricTensor, Kb)
+    return _tensor_invariant!(A, Kb)
 end
 
 ## Buoyancy forces

--- a/src/ext/CUDA/3D.jl
+++ b/src/ext/CUDA/3D.jl
@@ -242,8 +242,8 @@ function compute_viscosity!(η, ν, εII::CuArray, args, rheology, cutoff)
     return compute_viscosity!(η, ν, εII, args, rheology, cutoff)
 end
 ## Stress
-function JR3D.tensor_invariant!(::CUDABackendTrait, A::JustRelax.SymmetricTensor)
-    return _tensor_invariant!(A)
+function JR3D.tensor_invariant!(::CUDABackendTrait, A::JustRelax.SymmetricTensor, Kb)
+    return _tensor_invariant!(A, Kb)
 end
 
 ## Buoyancy forces


### PR DESCRIPTION
This is an attempt to fix the missing terms in the 2nd invariant calculation routines within JustRelax (internal function). 

There needs to be another PR dealing with this in GeoParams to fix all routines there. This requires a bit more rewriting due to the nested function calls. Especially as we call them in the stress update functions with `τII_ij = second_invariant(dτij .+ τij)`

cc @tduretz @boriskaus @albert-de-montserrat 