### PR TITLE
Improve correction of particles crossing a marker chain 

### DIFF
--- a/src/ext/CUDA/2D.jl
+++ b/src/ext/CUDA/2D.jl
@@ -442,6 +442,16 @@ function JR2D.rotate_stress!(
 end
 
 # marker chain
+function JR2D.update_phases_given_markerchain!(
+        phase,
+        chain::MarkerChain{CUDABackend},
+        particles::Particles{CUDABackend},
+        origin,
+        di,
+        air_phase,
+    ) where N
+    return update_phases_given_markerchain!(phase, chain, particles, origin, di, air_phase, ())
+end
 
 function JR2D.update_phases_given_markerchain!(
         phase,
@@ -450,8 +460,9 @@ function JR2D.update_phases_given_markerchain!(
         origin,
         di,
         air_phase,
-    )
-    return update_phases_given_markerchain!(phase, chain, particles, origin, di, air_phase)
+        args::NTuple{N, Any},
+    ) where N
+    return update_phases_given_markerchain!(phase, chain, particles, origin, di, air_phase, args)
 end
 
 end


### PR DESCRIPTION
`update_phases_given_markerchain!` now also takes a last argument which is a `Tuple` containing the fields stored by the particles, that need to be reset when a particle accidentally crosses the marker chain.