### PR TITLE
[BUGFIX] Fix calculation of thermal diffusivity 

### DIFF
--- a/miniapps/benchmarks/thermal_diffusion/diffusion/diffusion2D_multiphase.jl
+++ b/miniapps/benchmarks/thermal_diffusion/diffusion/diffusion2D_multiphase.jl
@@ -4,23 +4,11 @@ const backend_JR = CPUBackend
 using ParallelStencil
 @init_parallel_stencil(Threads, Float64, 2)  #or (CUDA, Float64, 2) or (AMDGPU, Float64, 2)
 
-
 using GeoParams
 using JustPIC, JustPIC._2D
 const backend = JustPIC.CPUBackend
 
 distance(p1, p2) = mapreduce(x -> (x[1] - x[2])^2, +, zip(p1, p2)) |> sqrt
-
-@parallel_indices (i, j) function init_T!(T, z)
-    if z[j] == maximum(z)
-        T[i + 1, j + 1] = 300.0
-    elseif z[j] == minimum(z)
-        T[i + 1, j + 1] = 3500.0
-    else
-        T[i + 1, j + 1] = z[j] * (1900.0 - 1600.0) / minimum(z) + 1600.0
-    end
-    return nothing
-end
 
 @parallel_indices (i, j) function init_T!(T, z, ly)
     T[i, j + 1] = -z[j] * (1900.0 - 1600.0) / ly + 1600.0
@@ -64,6 +52,13 @@ function init_phases!(phases, particles, xc, yc, r)
 
     return @parallel (@idx ni) init_phases!(phases, particles.coords..., particles.index, center, r)
 end
+
+nx = 32
+ny = 32
+lx = 100.0e3
+ly = 100.0e3
+Cp0 = 1.2e3
+K0 = 3.0
 
 function diffusion_2D(; nx = 32, ny = 32, lx = 100.0e3, ly = 100.0e3, Cp0 = 1.2e3, K0 = 3.0)
     kyr = 1.0e3 * 3600 * 24 * 365.25
@@ -110,7 +105,7 @@ function diffusion_2D(; nx = 32, ny = 32, lx = 100.0e3, ly = 100.0e3, Cp0 = 1.2e
         no_flux = (left = true, right = true, top = false, bot = false),
         constant_value = (left = false, right = false, top = Ttop, bot = Tbot),
     )
-    @parallel (1:(nx + 2), 1:ny) init_T!(thermal.T, xci[2])
+    @parallel (1:(nx + 2), 1:ny) init_T!(thermal.T, xci[2], li)
 
     # Add thermal perturbation
     δT = 100.0e0 # thermal perturbation

--- a/src/thermal_diffusion/DiffusionPT_GeoParams.jl
+++ b/src/thermal_diffusion/DiffusionPT_GeoParams.jl
@@ -89,10 +89,7 @@ end
 @inline function compute_diffusivity(
         rheology::NTuple{N, AbstractMaterialParamsStruct}, phase_ratios::SArray, args
     ) where {N}
-    ρ = compute_density_ratio(phase_ratios, rheology, args)
-    conductivity = fn_ratio(compute_conductivity, rheology, phase_ratios, args)
-    heatcapacity = fn_ratio(compute_heatcapacity, rheology, phase_ratios, args)
-    return conductivity * inv(heatcapacity * ρ)
+    return fn_ratio(compute_diffusivity, rheology, phase_ratios, args)
 end
 
 # ρ*Cp
@@ -115,8 +112,7 @@ end
 end
 
 @inline function compute_ρCp(rheology, phase_ratios::SArray, args)
-    return fn_ratio(compute_heatcapacity, rheology, phase_ratios, args) *
-        fn_ratio(compute_density, rheology, phase_ratios, args)
+    return fn_ratio(compute_ρCp, rheology, phase_ratios, args)
 end
 
 @inline function compute_ρCp(rheology, ρ, phase_ratios::SArray, args)


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

As reported by Bert, the calculation of thermal diffusivity in the case of multple phases is wrong. Now, thermal diffusivity is first calculated, then volumed averaged.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
