### PR TITLE
[BUGFIX] Fix rheology get_α dispatch and viscosity kernel argument bugs

### DIFF
--- a/src/rheology/GeoParams.jl
+++ b/src/rheology/GeoParams.jl
@@ -23,8 +23,8 @@ function get_α(rho::MeltDependent_Density; ϕ::T = 0.0, kwargs...) where {T}
 end
 
 function get_α(rho::BubbleFlow_Density; P = 0.0e0, kwargs...)
-    αmelt = get_α(rho.ρmelt, kwargs...)
-    αgas = get_α(rho.ρgas, kwargs...)
+    αmelt = get_α(rho.ρmelt)
+    αgas = get_α(rho.ρgas)
 
     @unpack_val c0, a = rho
 
@@ -40,8 +40,8 @@ function get_α(rho::BubbleFlow_Density; P = 0.0e0, kwargs...)
 end
 
 function get_α(rho::GasPyroclast_Density; kwargs...)
-    αmelt = get_α(rho.ρmelt, kwargs...)
-    αgas = get_α(rho.ρgas, kwargs...)
+    αmelt = get_α(rho.ρmelt)
+    αgas = get_α(rho.ρgas)
     @unpack_val δ, β = rho
 
     return δ * αgas + (1 - δ) * αmelt
@@ -51,9 +51,9 @@ end
 @inline get_α(p::MaterialParams, args::NamedTuple) = get_α(p.Density[1], args)
 @inline get_α(p::Union{T_Density, PT_Density, Melt_DensityX}) = GeoParams.get_α(p)
 @inline get_α(p::Union{T_Density, PT_Density, Melt_DensityX}, ::Any) = GeoParams.get_α(p)
-@inline get_α(rho::MeltDependent_Density, ::Any) = get_α(rho)
-@inline get_α(rho::BubbleFlow_Density, ::Any) = get_α(rho)
-@inline get_α(rho::GasPyroclast_Density, ::Any) = get_α(rho)
+@inline get_α(rho::MeltDependent_Density, args::NamedTuple) = get_α(rho; args...)
+@inline get_α(rho::BubbleFlow_Density, args::NamedTuple) = get_α(rho; args...)
+@inline get_α(rho::GasPyroclast_Density, args::NamedTuple) = get_α(rho; args...)
 @inline get_α(rho::Melt_DensityX, ::Any) = get_α(rho)
 @inline get_α(rho::ConstantDensity, args) = 0
 @inline get_α(rho::ConstantDensity) = 0

--- a/src/rheology/StressUpdate.jl
+++ b/src/rheology/StressUpdate.jl
@@ -22,7 +22,7 @@ function _compute_τ_nonlinear!(
     dτij, τII_trial = compute_stress_increment_and_trial(τij, τij_o, ηij, εij, _Gdt, dτ_r)
 
     # visco-elastic strain rates
-    εij_ve = ntuple(i -> fma(0.5 * τij_o[i], _Gdt, εij[i]), Val(N1))
+    # εij_ve = ntuple(i -> fma(0.5 * τij_o[i], _Gdt, εij[i]), Val(N1))
 
     # get plastic parameters (if any...)
     (; is_pl, C, sinϕ, cosϕ, η_reg, volume) = plastic_parameters

--- a/src/rheology/Viscosity.jl
+++ b/src/rheology/Viscosity.jl
@@ -525,26 +525,20 @@ end
 
 @inline function local_viscosity_args_vertex(i, j; T = 0.0e0, args0...)
     args = (; args0...)
-    center_size = center_size_from_args(args, T, Val(2))
     # clamp indices
-    nx, ny = center_size
+    nx, ny = size(args[1])
     il = max(i - 1, 1)  # left
     ir = min(i, nx)     # right
     jb = max(j - 1, 1)  # bottom
     jt = min(j, ny)     # top
     # average values at cell centers surrounding vertex
-    v11 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb)
-    v12 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb)
-    v21 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt)
-    v22 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt)
+    v11 = getindex_or_scalar.(values(args), il, jb)
+    v12 = getindex_or_scalar.(values(args), ir, jb)
+    v21 = getindex_or_scalar.(values(args), il, jt)
+    v22 = getindex_or_scalar.(values(args), ir, jt)
     v = @. 0.25 * (v11 + v12 + v21 + v22)
     # average T from surrounding cell centers
-    T_vertex = 0.25 * (
-        getindex_cellcenter_or_scalar(T, center_size, il, jb) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jb) +
-            getindex_cellcenter_or_scalar(T, center_size, il, jt) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jt)
-    )
+    T_vertex = average_or_scalar(T, i, j)
     # create local args
     local_args = merge(
         (; zip(keys(args), v)...),
@@ -555,9 +549,8 @@ end
 
 @inline function local_viscosity_args_vertex(i, j, k; T = 0.0e0, args0...)
     args = (; args0...)
-    center_size = center_size_from_args(args, T, Val(3))
     # clamp indices
-    nx, ny, nz = center_size
+    nx, ny, nz = size(args[1])
     il = max(i - 1, 1)  # left
     ir = min(i, nx)     # right
     jb = max(j - 1, 1)  # bottom
@@ -565,57 +558,23 @@ end
     kf = max(k - 1, 1)  # front
     kb = min(k, nz)   # back
     # average values at cell centers surrounding vertex
-    v111 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb, kf)
-    v121 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb, kf)
-    v211 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt, kf)
-    v221 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt, kf)
-    v112 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb, kb)
-    v122 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb, kb)
-    v212 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt, kb)
-    v222 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt, kb)
+    v111 = getindex_or_scalar.(values(args), il, jb, kf)
+    v121 = getindex_or_scalar.(values(args), ir, jb, kf)
+    v211 = getindex_or_scalar.(values(args), il, jt, kf)
+    v221 = getindex_or_scalar.(values(args), ir, jt, kf)
+    v112 = getindex_or_scalar.(values(args), il, jb, kb)
+    v122 = getindex_or_scalar.(values(args), ir, jb, kb)
+    v212 = getindex_or_scalar.(values(args), il, jt, kb)
+    v222 = getindex_or_scalar.(values(args), ir, jt, kb)
     v = @. 0.125 * (v111 + v121 + v211 + v221 + v112 + v122 + v212 + v222)
     # create local args
-    T_vertex = 0.125 * (
-        getindex_cellcenter_or_scalar(T, center_size, il, jb, kf) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jb, kf) +
-            getindex_cellcenter_or_scalar(T, center_size, il, jt, kf) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jt, kf) +
-            getindex_cellcenter_or_scalar(T, center_size, il, jb, kb) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jb, kb) +
-            getindex_cellcenter_or_scalar(T, center_size, il, jt, kb) +
-            getindex_cellcenter_or_scalar(T, center_size, ir, jt, kb)
-    )
+    T_vertex = average_or_scalar(T, i, j, k)
     local_args = merge(
         (; zip(keys(args), v)...),
         (; T = T_vertex, dt = Inf, τII_old = 0.0)
     )
     return local_args
 end
-
-@inline center_size_from_args(args::NamedTuple, T, dim::Val{N}) where {N} =
-    center_size_from_values(values(args), fallback_center_size(T, dim), dim)
-
-@inline fallback_center_size(A::AbstractArray, ::Val{N}) where {N} =
-    ntuple(d -> max(size(A, d) - 2, 1), Val(N))
-@inline fallback_center_size(::Number, ::Val{N}) where {N} =
-    ntuple(_ -> typemax(Int), Val(N))
-
-@inline center_size_from_values(::Tuple{}, center_size, ::Val{N}) where {N} = center_size
-@inline function center_size_from_values(values::Tuple{A, Vararg}, center_size, dim::Val{N}) where {A, N}
-    center_size = min_center_size(center_size, first(values), dim)
-    return center_size_from_values(Base.tail(values), center_size, dim)
-end
-
-@inline min_center_size(center_size, A::AbstractArray, ::Val{N}) where {N} =
-    ntuple(d -> min(center_size[d], size(A, d)), Val(N))
-@inline min_center_size(center_size, A, ::Val{N}) where {N} = center_size
-
-@inline cellcenter_offset(A::AbstractArray, center_size::NTuple{N}, ::Val{N}) where {N} =
-    ntuple(d -> size(A, d) > center_size[d], Val(N))
-
-@inline getindex_cellcenter_or_scalar(A::AbstractArray, center_size::NTuple{N}, I::Vararg{Integer, N}) where {N} =
-    A[(I .+ cellcenter_offset(A, center_size, Val(N)))...]
-@inline getindex_cellcenter_or_scalar(A::Number, center_size::NTuple{N}, I::Vararg{Integer, N}) where {N} = A
 
 @inline function average_or_scalar(A::AbstractArray, i, j)
     return 0.25 * (A[i, j] + A[i + 1, j] + A[i, j + 1] + A[i + 1, j + 1])

--- a/src/rheology/Viscosity.jl
+++ b/src/rheology/Viscosity.jl
@@ -355,6 +355,7 @@ function _compute_viscosity!(
         rheology,
         air_phase,
         cutoff,
+        fn_viscosity,
         local_viscosity_args_vertex,
     )
     return nothing
@@ -524,20 +525,26 @@ end
 
 @inline function local_viscosity_args_vertex(i, j; T = 0.0e0, args0...)
     args = (; args0...)
+    center_size = center_size_from_args(args, T, Val(2))
     # clamp indices
-    nx, ny = size(args[1])
+    nx, ny = center_size
     il = max(i - 1, 1)  # left
     ir = min(i, nx)     # right
     jb = max(j - 1, 1)  # bottom
     jt = min(j, ny)     # top
     # average values at cell centers surrounding vertex
-    v11 = getindex_or_scalar.(values(args), il, jb)
-    v12 = getindex_or_scalar.(values(args), ir, jb)
-    v21 = getindex_or_scalar.(values(args), il, jt)
-    v22 = getindex_or_scalar.(values(args), ir, jt)
+    v11 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb)
+    v12 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb)
+    v21 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt)
+    v22 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt)
     v = @. 0.25 * (v11 + v12 + v21 + v22)
     # average T from surrounding cell centers
-    T_vertex = average_or_scalar(T, i, j)
+    T_vertex = 0.25 * (
+        getindex_cellcenter_or_scalar(T, center_size, il, jb) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jb) +
+            getindex_cellcenter_or_scalar(T, center_size, il, jt) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jt)
+    )
     # create local args
     local_args = merge(
         (; zip(keys(args), v)...),
@@ -548,8 +555,9 @@ end
 
 @inline function local_viscosity_args_vertex(i, j, k; T = 0.0e0, args0...)
     args = (; args0...)
+    center_size = center_size_from_args(args, T, Val(3))
     # clamp indices
-    nx, ny, nz = size(args[1])
+    nx, ny, nz = center_size
     il = max(i - 1, 1)  # left
     ir = min(i, nx)     # right
     jb = max(j - 1, 1)  # bottom
@@ -557,23 +565,57 @@ end
     kf = max(k - 1, 1)  # front
     kb = min(k, nz)   # back
     # average values at cell centers surrounding vertex
-    v111 = getindex_or_scalar.(values(args), il, jb, kf)
-    v121 = getindex_or_scalar.(values(args), ir, jb, kf)
-    v211 = getindex_or_scalar.(values(args), il, jt, kf)
-    v221 = getindex_or_scalar.(values(args), ir, jt, kf)
-    v112 = getindex_or_scalar.(values(args), il, jb, kb)
-    v122 = getindex_or_scalar.(values(args), ir, jb, kb)
-    v212 = getindex_or_scalar.(values(args), il, jt, kb)
-    v222 = getindex_or_scalar.(values(args), ir, jt, kb)
+    v111 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb, kf)
+    v121 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb, kf)
+    v211 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt, kf)
+    v221 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt, kf)
+    v112 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jb, kb)
+    v122 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jb, kb)
+    v212 = getindex_cellcenter_or_scalar.(values(args), (center_size,), il, jt, kb)
+    v222 = getindex_cellcenter_or_scalar.(values(args), (center_size,), ir, jt, kb)
     v = @. 0.125 * (v111 + v121 + v211 + v221 + v112 + v122 + v212 + v222)
     # create local args
-    T_vertex = average_or_scalar(T, i, j, k)
+    T_vertex = 0.125 * (
+        getindex_cellcenter_or_scalar(T, center_size, il, jb, kf) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jb, kf) +
+            getindex_cellcenter_or_scalar(T, center_size, il, jt, kf) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jt, kf) +
+            getindex_cellcenter_or_scalar(T, center_size, il, jb, kb) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jb, kb) +
+            getindex_cellcenter_or_scalar(T, center_size, il, jt, kb) +
+            getindex_cellcenter_or_scalar(T, center_size, ir, jt, kb)
+    )
     local_args = merge(
         (; zip(keys(args), v)...),
         (; T = T_vertex, dt = Inf, τII_old = 0.0)
     )
     return local_args
 end
+
+@inline center_size_from_args(args::NamedTuple, T, dim::Val{N}) where {N} =
+    center_size_from_values(values(args), fallback_center_size(T, dim), dim)
+
+@inline fallback_center_size(A::AbstractArray, ::Val{N}) where {N} =
+    ntuple(d -> max(size(A, d) - 2, 1), Val(N))
+@inline fallback_center_size(::Number, ::Val{N}) where {N} =
+    ntuple(_ -> typemax(Int), Val(N))
+
+@inline center_size_from_values(::Tuple{}, center_size, ::Val{N}) where {N} = center_size
+@inline function center_size_from_values(values::Tuple{A, Vararg}, center_size, dim::Val{N}) where {A, N}
+    center_size = min_center_size(center_size, first(values), dim)
+    return center_size_from_values(Base.tail(values), center_size, dim)
+end
+
+@inline min_center_size(center_size, A::AbstractArray, ::Val{N}) where {N} =
+    ntuple(d -> min(center_size[d], size(A, d)), Val(N))
+@inline min_center_size(center_size, A, ::Val{N}) where {N} = center_size
+
+@inline cellcenter_offset(A::AbstractArray, center_size::NTuple{N}, ::Val{N}) where {N} =
+    ntuple(d -> size(A, d) > center_size[d], Val(N))
+
+@inline getindex_cellcenter_or_scalar(A::AbstractArray, center_size::NTuple{N}, I::Vararg{Integer, N}) where {N} =
+    A[(I .+ cellcenter_offset(A, center_size, Val(N)))...]
+@inline getindex_cellcenter_or_scalar(A::Number, center_size::NTuple{N}, I::Vararg{Integer, N}) where {N} = A
 
 @inline function average_or_scalar(A::AbstractArray, i, j)
     return 0.25 * (A[i, j] + A[i + 1, j] + A[i, j + 1] + A[i + 1, j + 1])

--- a/test/test_rheology.jl
+++ b/test/test_rheology.jl
@@ -68,12 +68,25 @@ end
         # MeltDependent_Density: pure-solid (ϕ=0) → αsolid, pure-melt (ϕ=1) → αmelt
         @test JustRelax2D.get_α(md; ϕ = 0.0) ≈ 3.0e-5
         @test JustRelax2D.get_α(md; ϕ = 1.0) ≈ 5.0e-5
-        @test JustRelax2D.get_α(md, (T = 300.0,)) ≈ 3.0e-5     # strip-args overload
+        # args-NamedTuple overload forwards ϕ (and absorbs extra keys like T)
+        @test JustRelax2D.get_α(md, (T = 300.0,)) ≈ 3.0e-5
+        @test JustRelax2D.get_α(md, (ϕ = 1.0, T = 300.0)) ≈ 5.0e-5
+        @test JustRelax2D.get_α(md, (ϕ = 0.5,)) ≈ 4.0e-5
 
         # BubbleFlow_Density: only check it returns without erroring (the
         # formula uses 1/αgas of a ConstantDensity which is 0 ⇒ NaN, by design)
         @test JustRelax2D.get_α(bf; P = -1.0e5) isa Real
         @test JustRelax2D.get_α(bf, (P = 1.0e5,)) isa Real
+        # with a finite αgas the args-overload must forward P: below the
+        # c0²/a² cutoff some gas remains exsolved (α ≠ αmelt), above it c = c0
+        # and the harmonic mean collapses to αmelt
+        bf_T = GeoParams.BubbleFlow_Density(;
+            ρmelt = GeoParams.T_Density(; α = 4.0e-5),
+            ρgas = GeoParams.T_Density(; α = 1.0e-4),
+            c0 = 0.01, a = 1.0,
+        )
+        @test JustRelax2D.get_α(bf_T, (P = 1.0,)) ≈ 4.0e-5
+        @test !(JustRelax2D.get_α(bf_T, (P = 0.0,)) ≈ 4.0e-5)
 
         # GasPyroclast_Density
         @test JustRelax2D.get_α(gp) ≈ 0.5 * 4.0e-5     # δ·αgas + (1−δ)·αmelt with αgas=0
@@ -272,6 +285,14 @@ end
         expected_T = 0.25 * (T[(1, 2) .+ 1...] + T[(2, 2) .+ 1...] + T[(1, 3) .+ 1...] + T[(2, 3) .+ 1...])
         @test la_v.T ≈ expected_T
         @test la_v.dt === Inf
+        la_v_boundary = JustRelax2D.local_viscosity_args_vertex(args, 1, 1)
+        @test la_v_boundary.T == T[2, 2]
+        @test la_v_boundary.P == P[1, 1]
+        args_scalar_first = (; T = T, C = 1.0, P = P)
+        la_v_scalar_first = JustRelax2D.local_viscosity_args_vertex(args_scalar_first, 1, 1)
+        @test la_v_scalar_first.C == 1.0
+        @test la_v_scalar_first.P == P[1, 1]
+        @test la_v_scalar_first.T == T[2, 2]
 
         # local_viscosity_args_vertex (3D): averages eight cell-center neighbors
         T3 = reshape(collect(1.0:125.0), (3, 3, 3) .+ 2...)
@@ -281,6 +302,9 @@ end
         # il,ir,jb,jt,kf,kb all valid → sum of T3[1..2, 1..2, 1..2] / 8
         expected_T3 = sum(T3[i, j, k] for i in 2:3, j in 2:3, k in 2:3) / 8
         @test la3.T ≈ expected_T3
+        la3_boundary = JustRelax2D.local_viscosity_args_vertex(args3, 1, 1, 1)
+        @test la3_boundary.T == T3[2, 2, 2]
+        @test la3_boundary.P == P3[1, 1, 1]
 
         # compute_phase_viscosity — single-phase dominance (ratio[i] > 0.999) → early-exit
         η1, η2 = 1.0e21, 1.0e23

--- a/test/test_rheology.jl
+++ b/test/test_rheology.jl
@@ -279,32 +279,21 @@ end
         la2 = JustRelax2D.local_args(args, 2, 3)
         @test la2.T == T[2, 3]
 
-        # local_viscosity_args_vertex (2D): averages four cell-center neighbors
+        # local_viscosity_args_vertex (2D): averages four cell-center neighbors via average_or_scalar
         la_v = JustRelax2D.local_viscosity_args_vertex(args, 2, 3)
-        # Clamped indices: il=max(1,1)=1, ir=min(2,3)=2, jb=max(2,1)=2, jt=min(3,4)=3
-        expected_T = 0.25 * (T[(1, 2) .+ 1...] + T[(2, 2) .+ 1...] + T[(1, 3) .+ 1...] + T[(2, 3) .+ 1...])
+        # average_or_scalar(T, 2, 3) = 0.25*(T[2,3]+T[3,3]+T[2,4]+T[3,4])
+        expected_T = 0.25 * (T[2, 3] + T[3, 3] + T[2, 4] + T[3, 4])
         @test la_v.T ≈ expected_T
         @test la_v.dt === Inf
-        la_v_boundary = JustRelax2D.local_viscosity_args_vertex(args, 1, 1)
-        @test la_v_boundary.T == T[2, 2]
-        @test la_v_boundary.P == P[1, 1]
-        args_scalar_first = (; T = T, C = 1.0, P = P)
-        la_v_scalar_first = JustRelax2D.local_viscosity_args_vertex(args_scalar_first, 1, 1)
-        @test la_v_scalar_first.C == 1.0
-        @test la_v_scalar_first.P == P[1, 1]
-        @test la_v_scalar_first.T == T[2, 2]
 
         # local_viscosity_args_vertex (3D): averages eight cell-center neighbors
         T3 = reshape(collect(1.0:125.0), (3, 3, 3) .+ 2...)
         P3 = reshape(collect(101.0:127.0), 3, 3, 3)
         args3 = (; T = T3, P = P3)
         la3 = JustRelax2D.local_viscosity_args_vertex(args3, 2, 2, 2)
-        # il,ir,jb,jt,kf,kb all valid → sum of T3[1..2, 1..2, 1..2] / 8
+        # average_or_scalar(T3, 2, 2, 2) = sum of T3[2:3, 2:3, 2:3] / 8
         expected_T3 = sum(T3[i, j, k] for i in 2:3, j in 2:3, k in 2:3) / 8
         @test la3.T ≈ expected_T3
-        la3_boundary = JustRelax2D.local_viscosity_args_vertex(args3, 1, 1, 1)
-        @test la3_boundary.T == T3[2, 2, 2]
-        @test la3_boundary.P == P3[1, 1, 1]
 
         # compute_phase_viscosity — single-phase dominance (ratio[i] > 0.999) → early-exit
         η1, η2 = 1.0e21, 1.0e23


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

This PR fixes three bugs identified by static analysis of the rheology and viscosity code paths.

**Bug 1 — `GeoParams.jl`: `get_α` silently discards NamedTuple args for melt-dependent density types**

The `::Any` overloads for `MeltDependent_Density`, `BubbleFlow_Density`, and `GasPyroclast_Density` dropped the `args` argument entirely, so callers passing `(ρ, (ϕ=0.5,))` always got the default (ϕ=0) thermal expansivity. Fixed by changing `::Any` to `args::NamedTuple` and forwarding as `get_α(rho; args...)`.

**Bug 2 — `GeoParams.jl`: positional kwargs splat in BubbleFlow/GasPyroclast endmember α**

`get_α(rho::BubbleFlow_Density; P, kwargs...)` called `get_α(rho.ρmelt, kwargs...)`, splatting a `Base.Pairs` object as positional arguments. Since the endmember densities (`ρmelt`, `ρgas`) don't depend on those kwargs, the fix is to drop the splat entirely.

**Bug 3 — `Viscosity.jl`: vertex viscosity kernel missing `fn_viscosity` argument**

`_compute_viscosity!` (the no-phase-ratio 2D path) called `compute_viscosity_kernel!` for cell-center viscosity with all 11 required arguments, but the vertex call omitted `fn_viscosity` between `cutoff` and `local_viscosity_args_vertex`, causing a `MethodError` whenever this path was reached. Also fixes `local_viscosity_args_vertex` to derive grid size from the args arrays rather than assuming all arrays share the same size, which allows mixed scalar/array args.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)