### PR TITLE
[PERF] Fuse DYREL kernels

### DIFF
--- a/src/DYREL/constructors.jl
+++ b/src/DYREL/constructors.jl
@@ -42,12 +42,17 @@ function DYREL(ni::NTuple{2}; ϵ = 1.0e-6, ϵ_vel = 1.0e-6, CFL = 0.99, c_fact =
     αVx = @zeros(nx - 1, ny)
     αVy = @zeros(nx, ny - 1)
     αVz = @zeros(1, 1)  # dummy for 2D
+    P_num = @zeros(nx, ny)
+    Rx0 = @zeros(nx - 1, ny)
+    Ry0 = @zeros(nx, ny - 1)
+    Rz0 = @zeros(1, 1)  # dummy for 2D
 
     T = typeof(γ_eff)
     F = typeof(CFL)
     return JustRelax.DYREL{T, F}(
         γ_eff, Dx, Dy, Dz, λmaxVx, λmaxVy, λmaxVz, dVxdτ, dVydτ, dVzdτ, dτVx, dτVy, dτVz,
-        dVx, dVy, dVz, βVx, βVy, βVz, cVx, cVy, cVz, αVx, αVy, αVz, ηb, CFL, ϵ, ϵ_vel, c_fact
+        dVx, dVy, dVz, βVx, βVy, βVz, cVx, cVy, cVz, αVx, αVy, αVz, ηb, P_num, Rx0, Ry0,
+        Rz0, CFL, ϵ, ϵ_vel, c_fact
     )
 end
 
@@ -85,12 +90,17 @@ function DYREL(ni::NTuple{3}; ϵ = 1.0e-6, ϵ_vel = 1.0e-6, CFL = 0.99, c_fact =
     αVx = @zeros(nx - 1, ny, nz)
     αVy = @zeros(nx, ny - 1, nz)
     αVz = @zeros(nx, ny, nz - 1)
+    P_num = @zeros(nx, ny, nz)
+    Rx0 = @zeros(nx - 1, ny, nz)
+    Ry0 = @zeros(nx, ny - 1, nz)
+    Rz0 = @zeros(nx, ny, nz - 1)
 
     T = typeof(γ_eff)
     F = typeof(CFL)
     return JustRelax.DYREL{T, F}(
         γ_eff, Dx, Dy, Dz, λmaxVx, λmaxVy, λmaxVz, dVxdτ, dVydτ, dVzdτ, dτVx, dτVy, dτVz,
-        dVx, dVy, dVz, βVx, βVy, βVz, cVx, cVy, cVz, αVx, αVy, αVz, ηb, CFL, ϵ, ϵ_vel, c_fact
+        dVx, dVy, dVz, βVx, βVy, βVz, cVx, cVy, cVz, αVx, αVy, αVz, ηb, P_num, Rx0, Ry0,
+        Rz0, CFL, ϵ, ϵ_vel, c_fact
     )
 end
 

--- a/src/DYREL/pressure_kernels.jl
+++ b/src/DYREL/pressure_kernels.jl
@@ -111,3 +111,19 @@ end
 
 @inline _compute_RP!(P, P0, ∇V, Q, ηb, dt) = -∇V - (P - P0) / ηb + (Q / dt)
 @inline _compute_RP!(P, P0, ∇V, Q, ΔT, α, ηb, dt) = -∇V - (P - P0) / ηb + α * (ΔT / dt) + (Q / dt)
+
+# Per-cell pressure residual, dispatching on the presence of ΔT / melt_fraction exactly as
+# `compute_RP_kernel!` does. Used to fold the RP computation into the strain-rate kernel while
+# reusing `_compute_RP!` and keeping the thermal branch resolved at compile time (GPU-friendly).
+@inline _RP_cell(P, P0, ∇V, Q, ηb, dt, rheology, phase_ratio, ::Nothing, ::Nothing, I::Vararg{Int}) =
+    _compute_RP!(P, P0, ∇V, Q, ηb, dt)
+@inline _RP_cell(P, P0, ∇V, Q, ηb, dt, rheology, phase_ratio, ::Nothing, melt_fraction, I::Vararg{Int}) =
+    _compute_RP!(P, P0, ∇V, Q, ηb, dt)
+@inline function _RP_cell(P, P0, ∇V, Q, ηb, dt, rheology, phase_ratio, ΔT, ::Nothing, I::Vararg{Int})
+    α = fn_ratio(get_thermal_expansion, rheology, phase_ratio[I...])
+    return _compute_RP!(P, P0, ∇V, Q, ΔT[(I .+ 1)...], α, ηb, dt)
+end
+@inline function _RP_cell(P, P0, ∇V, Q, ηb, dt, rheology, phase_ratio, ΔT, melt_fraction, I::Vararg{Int})
+    α = fn_ratio(get_thermal_expansion, rheology, @cell(phase_ratio[I...]), (; ϕ = melt_fraction[I...]))
+    return _compute_RP!(P, P0, ∇V, Q, ΔT[(I .+ 1)...], α, ηb, dt)
+end

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -84,7 +84,7 @@ function _solve_DYREL!(
 
     # solver loop
     @copy stokes.P0 stokes.P
-    residuals0 = map(similar, residuals)
+    residuals0 = fields.R0
 
     for Aij in @tensor_center(stokes.ε_pl)
         Aij .= 0.0
@@ -108,7 +108,7 @@ function _solve_DYREL!(
     err_evo_P = Float64[]
     err_evo_it = Float64[]
     itg = 0
-    P_num = similar(stokes.P)
+    P_num = dyrel.P_num
 
     # recompute all the DYREL variables
     compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
@@ -313,6 +313,7 @@ end
         βV = (dyrel.βVx, dyrel.βVy),
         cV = (dyrel.cVx, dyrel.cVy),
         αV = (dyrel.αVx, dyrel.αVy),
+        R0 = (dyrel.Rx0, dyrel.Ry0),
     )
 end
 
@@ -326,6 +327,7 @@ end
         βV = (dyrel.βVx, dyrel.βVy, dyrel.βVz),
         cV = (dyrel.cVx, dyrel.cVy, dyrel.cVz),
         αV = (dyrel.αVx, dyrel.αVy, dyrel.αVz),
+        R0 = (dyrel.Rx0, dyrel.Ry0, dyrel.Rz0),
     )
 end
 

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -123,23 +123,12 @@ function _solve_DYREL!(
         # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
         compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
 
-        # compute deviatoric stress
-        compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_PH, dt)
+        # compute deviatoric stress and refresh τII viscosity in one pass
+        compute_stress_viscosity_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_PH, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
         # update_halo!(stokes.λv)
         # update_halo!(stokes.τ.xx_v)
         # update_halo!(stokes.τ.yy_v)
         # update_halo!(stokes.τ.xy)
-
-        if !linear_viscosity
-            update_viscosity_τII!(
-                stokes,
-                phase_ratios,
-                args,
-                rheology,
-                viscosity_cutoff;
-                relaxation = viscosity_relaxation,
-            )
-        end
 
         # compute velocity residuals
         @parallel (@idx ni) compute_PH_residual_V!(
@@ -200,21 +189,16 @@ function _solve_DYREL!(
             # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
             compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
 
-            # Deviatoric stress
-            compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_DR, dt)
+            # Deviatoric stress and τII viscosity refresh in one pass
+            compute_stress_viscosity_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_DR, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
             # update_halo!(stokes.λv)
-            # batch the vertex-stress halos into a single MPI exchange
-            update_halo!(stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy)
-
-            if !linear_viscosity
-                update_viscosity_τII!(
-                    stokes,
-                    phase_ratios,
-                    args,
-                    rheology,
-                    viscosity_cutoff;
-                    relaxation = viscosity_relaxation,
-                )
+            # batch the vertex-stress halos (+ vertex viscosity, refreshed above in the fused
+            # kernel from pre-halo stress) into a single MPI exchange, so shared boundary vertices
+            # stay consistent across ranks — matching the original stress→halo→viscosity ordering.
+            if linear_viscosity
+                update_halo!(stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy)
+            else
+                update_halo!(stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy, stokes.viscosity.ηv)
             end
 
             # Velocity residuals + damped pseudo-transient velocity update (fused; P_num already

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -121,7 +121,7 @@ function _solve_DYREL!(
         update_ρg!(ρg, phase_ratios, rheology, args)
 
         # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
-        compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
+        compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
 
         # compute deviatoric stress
         compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_PH, dt)
@@ -198,14 +198,13 @@ function _solve_DYREL!(
             iszero(iter % nout) && foreach(copyto!, residuals0, residuals)
 
             # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
-            compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
+            compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
 
             # Deviatoric stress
             compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_DR, dt)
             # update_halo!(stokes.λv)
-            update_halo!(stokes.τ.xx_v)
-            update_halo!(stokes.τ.yy_v)
-            update_halo!(stokes.τ.xy)
+            # batch the vertex-stress halos into a single MPI exchange
+            update_halo!(stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy)
 
             if !linear_viscosity
                 update_viscosity_τII!(

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -108,7 +108,10 @@ function _solve_DYREL!(
     err_evo_P = Float64[]
     err_evo_it = Float64[]
     itg = 0
-    P_num = dyrel.P_num
+    # small pressure correction θc = P_num + ΔPψ = γ_eff·RP + ΔPψ, assembled by the stress kernel and
+    # read (alongside the separately-differenced P) by the momentum kernel. Reuses the dyrel.P_num
+    # scratch — P_num is no longer materialized separately.
+    θc = dyrel.P_num
 
     # recompute all the DYREL variables
     compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
@@ -120,11 +123,11 @@ function _solve_DYREL!(
         # update buoyancy forces
         update_ρg!(ρg, phase_ratios, rheology, args)
 
-        # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
-        compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
+        # compute divergence, deviatoric strain rate and pressure residual in one pass
+        compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
 
-        # compute deviatoric stress and refresh τII viscosity in one pass
-        compute_stress_viscosity_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_PH, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
+        # compute deviatoric stress, refresh τII viscosity, and assemble θc = γ_eff·RP + ΔPψ in one pass
+        compute_stress_viscosity_DRYEL!(stokes, θc, dyrel.γ_eff, rheology, phase_ratios, λ_relaxation_PH, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
         # update_halo!(stokes.λv)
         # update_halo!(stokes.τ.xx_v)
         # update_halo!(stokes.τ.yy_v)
@@ -186,11 +189,11 @@ function _solve_DYREL!(
             # Pseudo-old dudes (only needed by compute_λminV! on residual-check iterations)
             iszero(iter % nout) && foreach(copyto!, residuals0, residuals)
 
-            # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
-            compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
+            # compute divergence, deviatoric strain rate and pressure residual in one pass
+            compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
 
-            # Deviatoric stress and τII viscosity refresh in one pass
-            compute_stress_viscosity_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_DR, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
+            # Deviatoric stress, τII viscosity refresh, and θc = γ_eff·RP + ΔPψ assembly in one pass
+            compute_stress_viscosity_DRYEL!(stokes, θc, dyrel.γ_eff, rheology, phase_ratios, λ_relaxation_DR, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
             # update_halo!(stokes.λv)
             # batch the vertex-stress halos (+ vertex viscosity, refreshed above in the fused
             # kernel from pre-halo stress) into a single MPI exchange, so shared boundary vertices
@@ -201,15 +204,14 @@ function _solve_DYREL!(
                 update_halo!(stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy, stokes.viscosity.ηv)
             end
 
-            # Velocity residuals + damped pseudo-transient velocity update (fused; P_num already
-            # computed above in compute_∇V_strain_rate_RP!)
+            # Velocity residuals + damped pseudo-transient velocity update (fused; the small pressure
+            # correction θc = γ_eff·RP + ΔPψ was assembled by the stress kernel above; P stays separate)
             @parallel (@idx ni) compute_DR_residual_update_V!(
                 residuals...,
                 @velocity(stokes)...,
                 fields.dVdτ...,
                 stokes.P,
-                P_num,
-                stokes.ΔPψ,
+                θc,
                 @stress(stokes)...,
                 ρg...,
                 fields.D...,
@@ -263,6 +265,10 @@ function _solve_DYREL!(
 
     # absorb plastic pressure correction into P (mirrors APT: stokes.P .= θ = P + ΔPψ)
     @. stokes.P += stokes.ΔPψ
+
+    # refresh the ∇V diagnostic from the converged velocity field (it is not stored inside the
+    # DYREL/PH loop — see compute_∇V_strain_rate_RP!)
+    @parallel (@idx ni) compute_∇V!(stokes.∇V, @velocity(stokes), _di.vertex)
 
     # compute vorticity
     compute_vorticity!(stokes, _di, ni, dim)

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -120,8 +120,8 @@ function _solve_DYREL!(
         # update buoyancy forces
         update_ρg!(ρg, phase_ratios, rheology, args)
 
-        # compute divergence and deviatoric strain rate in one pass
-        compute_∇V_strain_rate!(stokes, _di, ni, dim)
+        # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
+        compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
 
         # compute deviatoric stress
         compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_PH, dt)
@@ -152,19 +152,7 @@ function _solve_DYREL!(
             _di.vertex,
         )
 
-        # compute pressure residual
-        compute_residual_P!(
-            stokes.R.RP,
-            stokes.P,
-            stokes.P0,
-            stokes.∇V,
-            stokes.Q, # volumetric source/sink term
-            dyrel.ηb,
-            rheology,
-            phase_ratios,
-            dt,
-            args,
-        )
+        # pressure residual stokes.R.RP already computed in compute_∇V_strain_rate_RP! above
 
         # Residual check
         errV = ntuple(d -> norm_mpi(residuals[d]) / √(v_dofs[d]), dim)
@@ -206,11 +194,11 @@ function _solve_DYREL!(
             itg += 1
             iter += 1
 
-            # Pseudo-old dudes
-            foreach(copyto!, residuals0, residuals)
+            # Pseudo-old dudes (only needed by compute_λminV! on residual-check iterations)
+            iszero(iter % nout) && foreach(copyto!, residuals0, residuals)
 
-            # compute divergence and deviatoric strain rate in one pass
-            compute_∇V_strain_rate!(stokes, _di, ni, dim)
+            # compute divergence, deviatoric strain rate, pressure residual and P_num in one pass
+            compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
 
             # Deviatoric stress
             compute_stress_DRYEL!(stokes, rheology, phase_ratios, λ_relaxation_DR, dt)
@@ -218,19 +206,6 @@ function _solve_DYREL!(
             update_halo!(stokes.τ.xx_v)
             update_halo!(stokes.τ.yy_v)
             update_halo!(stokes.τ.xy)
-
-            compute_residual_P!(
-                stokes.R.RP,
-                stokes.P,
-                stokes.P0,
-                stokes.∇V,
-                stokes.Q, # volumetric source/sink term
-                dyrel.ηb,
-                rheology,
-                phase_ratios,
-                dt,
-                args,
-            )
 
             if !linear_viscosity
                 update_viscosity_τII!(
@@ -243,28 +218,23 @@ function _solve_DYREL!(
                 )
             end
 
-            # Residuals
-            @. P_num = dyrel.γ_eff * stokes.R.RP
-            @parallel (@idx ni) compute_DR_residual_V!(
+            # Velocity residuals + damped pseudo-transient velocity update (fused; P_num already
+            # computed above in compute_∇V_strain_rate_RP!)
+            @parallel (@idx ni) compute_DR_residual_update_V!(
                 residuals...,
+                @velocity(stokes)...,
+                fields.dVdτ...,
                 stokes.P,
                 P_num,
                 stokes.ΔPψ,
                 @stress(stokes)...,
                 ρg...,
                 fields.D...,
+                fields.αV...,
+                fields.βV...,
+                fields.dτV...,
                 _di.center,
                 _di.vertex,
-            )
-
-            # Damping and pseudo-transient velocity updates
-            @parallel (@idx ni) update_V_damping_DR_V!(
-                @velocity(stokes),
-                fields.dVdτ,
-                residuals,
-                fields.αV,
-                fields.βV,
-                fields.dτV,
             )
             flow_bcs!(stokes, flow_bcs)
             update_halo!(@velocity(stokes)...)

--- a/src/DYREL/stress_kernels.jl
+++ b/src/DYREL/stress_kernels.jl
@@ -92,6 +92,127 @@ end
     return nothing
 end
 
+## FUSED STRESS + τII-VISCOSITY UPDATE
+# Same as `compute_stress_DRYEL!` but, unless `linear_viscosity`, also refreshes the creep
+# viscosities η (center) / ηv (vertex) from the freshly-computed stress, reusing the in-register
+# τ instead of relaunching a kernel that reads the stress tensor back. The τII-viscosity update
+# is purely local (same cell), so this is race-free and needs no halo.
+function compute_stress_viscosity_DRYEL!(
+        stokes, rheology, phase_ratios, λ_relaxation, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity
+    )
+    ni = size(phase_ratios.vertex)
+    @parallel (@idx ni) compute_stress_viscosity_DRYEL!(
+        (stokes.τ.xx, stokes.τ.yy, stokes.τ.xy_c),          # centers
+        (stokes.τ.xx_v, stokes.τ.yy_v, stokes.τ.xy),        # vertices
+        (stokes.τ_o.xx, stokes.τ_o.yy, stokes.τ_o.xy_c),    # centers
+        (stokes.τ_o.xx_v, stokes.τ_o.yy_v, stokes.τ_o.xy),  # vertices
+        stokes.τ.II,
+        (stokes.ε.xx, stokes.ε.yy, stokes.ε.xy),            # staggered grid
+        (stokes.ε_pl.xx, stokes.ε_pl.yy, stokes.ε_pl.xy),   # centers
+        stokes.EII_pl,                                      # accumulated plastic strain rate @ centers
+        stokes.ε_vol_pl,                                    # volumetric plastic strain rate @ centers
+        stokes.P,
+        stokes.λ,
+        stokes.λv,
+        stokes.viscosity.η,
+        stokes.viscosity.ηv,
+        stokes.viscosity.η_vep,
+        stokes.ΔPψ,
+        rheology, phase_ratios.center, phase_ratios.vertex, λ_relaxation, dt,
+        viscosity_relaxation, args, viscosity_cutoff, linear_viscosity,
+    )
+    return nothing
+end
+
+# local τII-based creep viscosity, mirroring compute_viscosity_kernel! (τII path, air_phase = 0)
+@inline function _update_τII_viscosity(τxx, τyy, τxy, ratio, rheology, args_ij, η_old, ν, cutoff)
+    AII_0 = allzero(τxx, τyy, τxy) * eps()
+    τII = second_invariant(τxx + AII_0, τyy - AII_0, τxy)
+    ηi = compute_phase_viscosity(rheology, ratio, τII, compute_viscosity_τII, args_ij)
+    ηi = continuation_linear(ηi, η_old, ν)
+    return clamp(ηi, cutoff...)
+end
+
+@parallel_indices (I...) function compute_stress_viscosity_DRYEL!(
+        τ,
+        τ_v,
+        τ_o,
+        τ_ov,
+        τII,
+        ε,
+        ε_pl,
+        EII_pl,
+        ε_vol_pl,
+        P,
+        λ,
+        λv,
+        η,
+        ηv,
+        η_vep,
+        ΔPψ,
+        rheology, phase_ratios_center, phase_ratios_vertex, λ_relaxation, dt,
+        ν, visc_args, cutoff, linear_viscosity
+    )
+
+    Base.@propagate_inbounds @inline av(A) = sum(JustRelax2D._gather(A, I...)) / 4
+
+    ni = size(phase_ratios_center)
+
+    ## VERTEX CALCULATION
+    @inbounds begin
+        Ic = clamped_indices(ni, I...)
+        τij_o = τ_ov[1][I...], τ_ov[2][I...], τ_ov[3][I...]
+        εij = av_clamped(ε[1], Ic...), av_clamped(ε[2], Ic...), ε[3][I...]
+        λvij = λv[I...]
+        ηij = ηv[I...]
+        Pij = av_clamped(P, Ic...)
+        EIIv = av_clamped(EII_pl, Ic...)
+        ratio = phase_ratios_vertex[I...]
+        # compute local stress
+        τxx_I, τyy_I, τxy_I, εxx_pl, εyy_pl, εxy_pl, _, λ_I, = compute_local_stress(εij, τij_o, ηij, Pij, λvij, λ_relaxation, rheology, ratio, dt, EIIv)
+
+        # update arrays
+        τ_v[1][I...], τ_v[2][I...], τ_v[3][I...] = τxx_I, τyy_I, τxy_I
+        ε_pl[3][I...] = εxy_pl
+        λv[I...] = λ_I
+
+        # fused τII-viscosity update at the vertex (reuses in-register stress)
+        if !linear_viscosity
+            ηv[I...] = _update_τII_viscosity(τxx_I, τyy_I, τxy_I, ratio, rheology, local_viscosity_args_vertex(visc_args, I...), ηij, ν, cutoff)
+        end
+
+        ## CENTER CALCULATION
+        if all(I .≤ ni)
+            τij_o = τ_o[1][I...], τ_o[2][I...], τ_o[3][I...]
+            εij = ε[1][I...], ε[2][I...], av(ε[3])
+            λij = λ[I...]
+            ηij = η[I...]
+            Pij = P[I...]
+            EII = EII_pl[I...]
+            ratio = phase_ratios_center[I...]
+
+            # compute local stress
+            τxx_I, τyy_I, τxy_I, εxx_pl, εyy_pl, εxy_pl, τII_I, λ_I, ΔPψ_I, ηvep_I, ε_vol_pl_I =
+                compute_local_stress(εij, τij_o, ηij, Pij, λij, λ_relaxation, rheology, ratio, dt, EII)
+            # update arrays
+            τ[1][I...], τ[2][I...], τ[3][I...] = τxx_I, τyy_I, τxy_I
+            ε_pl[1][I...], ε_pl[2][I...] = εxx_pl, εyy_pl
+            ε_vol_pl[I...] = ε_vol_pl_I
+            τII[I...] = τII_I
+            η_vep[I...] = ηvep_I
+            λ[I...] = λ_I
+            ΔPψ[I...] = ΔPψ_I
+
+            # fused τII-viscosity update at the center (reuses in-register stress)
+            if !linear_viscosity
+                η[I...] = _update_τII_viscosity(τxx_I, τyy_I, τxy_I, ratio, rheology, local_viscosity_args(visc_args, I...), ηij, ν, cutoff)
+            end
+        end
+    end
+
+    return nothing
+end
+
 @generated function compute_local_stress(εij, τij_o, η, P, λ, λ_relaxation, rheology, phase_ratio::SVector{N}, dt, EII) where {N}
     return quote
         @inline

--- a/src/DYREL/stress_kernels.jl
+++ b/src/DYREL/stress_kernels.jl
@@ -98,7 +98,7 @@ end
 # τ instead of relaunching a kernel that reads the stress tensor back. The τII-viscosity update
 # is purely local (same cell), so this is race-free and needs no halo.
 function compute_stress_viscosity_DRYEL!(
-        stokes, rheology, phase_ratios, λ_relaxation, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity
+        stokes, θc, γ_eff, rheology, phase_ratios, λ_relaxation, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity
     )
     ni = size(phase_ratios.vertex)
     @parallel (@idx ni) compute_stress_viscosity_DRYEL!(
@@ -118,6 +118,7 @@ function compute_stress_viscosity_DRYEL!(
         stokes.viscosity.ηv,
         stokes.viscosity.η_vep,
         stokes.ΔPψ,
+        θc, stokes.R.RP, γ_eff,                             # small pressure correction θc = γ_eff·RP + ΔPψ
         rheology, phase_ratios.center, phase_ratios.vertex, λ_relaxation, dt,
         viscosity_relaxation, args, viscosity_cutoff, linear_viscosity,
     )
@@ -150,6 +151,7 @@ end
         ηv,
         η_vep,
         ΔPψ,
+        θc, RP, γ_eff,
         rheology, phase_ratios_center, phase_ratios_vertex, λ_relaxation, dt,
         ν, visc_args, cutoff, linear_viscosity
     )
@@ -202,6 +204,12 @@ end
             η_vep[I...] = ηvep_I
             λ[I...] = λ_I
             ΔPψ[I...] = ΔPψ_I
+
+            # small pressure correction θc = P_num + ΔPψ = γ_eff·RP + ΔPψ (ΔPψ_I in-register). Both
+            # terms are small corrections of similar magnitude, so summing them is precision-safe;
+            # the large hydrostatic P is kept separate in the momentum kernel. Collapses the momentum
+            # stencil from three pressure reads (P, P_num, ΔPψ) to two (P, θc).
+            θc[I...] = γ_eff[I...] * RP[I...] + ΔPψ_I
 
             # fused τII-viscosity update at the center (reuses in-register stress)
             if !linear_viscosity

--- a/src/DYREL/types.jl
+++ b/src/DYREL/types.jl
@@ -14,6 +14,8 @@ Structure containing parameters and arrays for the DYREL (Dynamic Relaxation) so
 - `cVx`, `cVy`, `cVz`: Damping coefficients related to dynamic relaxation.
 - `αVx`, `αVy`, `αVz`: Scaling factors for damping.
 - `ηb`: Bulk viscosity field.
+- `P_num`: Numerical pressure scratch field.
+- `Rx0`, `Ry0`, `Rz0`: Velocity residual history scratch fields.
 - `CFL`: Courant-Friedrichs-Lewy number.
 - `ϵ`: General convergence tolerance.
 - `ϵ_vel`: Velocity convergence tolerance.
@@ -46,6 +48,10 @@ struct DYREL{T, F}
     αVy::T    # damping coefficients
     αVz::T    # damping coefficients (3D)
     ηb::T     # bulk viscosity
+    P_num::T  # numerical pressure scratch
+    Rx0::T    # velocity residual history scratch
+    Ry0::T    # velocity residual history scratch
+    Rz0::T    # velocity residual history scratch (3D)
     CFL::F    # Courant-Friedrichs-Lewy condition
     ϵ::F      # convergence criterion
     ϵ_vel::F  # convergence criterion

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -139,6 +139,186 @@ end
     return nothing
 end
 
+## DIVERGENCE + DEVIATORIC STRAIN RATE + PRESSURE RESIDUAL (fused)
+# Same as `compute_∇V_strain_rate!` but additionally evaluates the pressure residual RP and the
+# numerical pressure P_num = γ_eff * RP in the same pass, reusing the in-register divergence
+# `div_ij` instead of reading ∇V back. RP and P_num are local per-center writes (no halo needed).
+
+function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
+    ΔT = haskey(args, :ΔT) ? args.ΔT : nothing
+    melt_fraction = haskey(args, :melt_fraction) ? args.melt_fraction : nothing
+    @parallel (@idx ni .+ 1) compute_∇V_strain_rate_RP!(
+        stokes.∇V,
+        @strain(stokes)...,
+        @velocity(stokes)...,
+        stokes.R.RP,
+        P_num,
+        stokes.P,
+        stokes.P0,
+        stokes.Q,
+        dyrel.ηb,
+        dyrel.γ_eff,
+        _di.vertex,
+        _di.velocity...,
+        rheology,
+        phase_ratios.center,
+        ΔT,
+        melt_fraction,
+        dt,
+    )
+    return interpolate_shear_ε_to_centers(stokes, dim)
+end
+
+@parallel_indices (i, j) function compute_∇V_strain_rate_RP!(
+        ∇V::AbstractArray{T, 2},
+        εxx,
+        εyy,
+        εxy,
+        Vx,
+        Vy,
+        RP,
+        P_num,
+        P,
+        P0,
+        Q,
+        ηb,
+        γ_eff,
+        _di_vertex,
+        _di_vx,
+        _di_vy,
+        rheology,
+        phase_ratio,
+        ΔT,
+        melt_fraction,
+        dt,
+    ) where {T}
+
+    third = T(1) / T(3)
+
+    @inbounds begin
+        vx_s = Vx[i, j]
+        vx_n = Vx[i, j + 1]
+        vy_w = Vy[i, j]
+        vy_e = Vy[i + 1, j]
+
+        if i ≤ size(εxy, 1) && j ≤ size(εxy, 2)
+            _dy_vx = @dy(_di_vx, j)
+            _dx_vy = @dx(_di_vy, i)
+
+            dVx_dy = (vx_n - vx_s) * _dy_vx
+            dVy_dx = (vy_e - vy_w) * _dx_vy
+            εxy[i, j] = 0.5 * (dVx_dy + dVy_dx)
+        end
+
+        if i ≤ size(∇V, 1) && j ≤ size(∇V, 2)
+            vx_ne = Vx[i + 1, j + 1]
+            vy_ne = Vy[i + 1, j + 1]
+            _dx, _dy = @dxi(_di_vertex, i, j)
+
+            dVx_dx = (vx_ne - vx_n) * _dx
+            dVy_dy = (vy_ne - vy_e) * _dy
+            div_ij = dVx_dx + dVy_dy
+            ∇V[i, j] = div_ij
+
+            div_third = div_ij * third
+            εxx[i, j] = dVx_dx - div_third
+            εyy[i, j] = dVy_dy - div_third
+
+            # fused pressure residual + numerical pressure (reuses `div_ij` in-register)
+            RP_ij = _RP_cell(P[i, j], P0[i, j], div_ij, Q[i, j], ηb[i, j], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j)
+            RP[i, j] = RP_ij
+            P_num[i, j] = γ_eff[i, j] * RP_ij
+        end
+    end
+
+    return nothing
+end
+
+@parallel_indices (i, j, k) function compute_∇V_strain_rate_RP!(
+        ∇V::AbstractArray{T, 3},
+        εxx,
+        εyy,
+        εzz,
+        εyz,
+        εxz,
+        εxy,
+        Vx,
+        Vy,
+        Vz,
+        RP,
+        P_num,
+        P,
+        P0,
+        Q,
+        ηb,
+        γ_eff,
+        _di_vertex,
+        _di_vx,
+        _di_vy,
+        _di_vz,
+        rheology,
+        phase_ratio,
+        ΔT,
+        melt_fraction,
+        dt,
+    ) where {T}
+
+    third = T(1) / T(3)
+
+    @inbounds begin
+        if all((i, j, k) .≤ size(∇V))
+            _dx, _dy, _dz = @dxi(_di_vertex, i, j, k)
+            dVx_dx = (Vx[i + 1, j + 1, k + 1] - Vx[i, j + 1, k + 1]) * _dx
+            dVy_dy = (Vy[i + 1, j + 1, k + 1] - Vy[i + 1, j, k + 1]) * _dy
+            dVz_dz = (Vz[i + 1, j + 1, k + 1] - Vz[i + 1, j + 1, k]) * _dz
+            div_ijk = dVx_dx + dVy_dy + dVz_dz
+            ∇V[i, j, k] = div_ijk
+
+            div_third = div_ijk * third
+            εxx[i, j, k] = dVx_dx - div_third
+            εyy[i, j, k] = dVy_dy - div_third
+            εzz[i, j, k] = dVz_dz - div_third
+
+            # fused pressure residual + numerical pressure (reuses `div_ijk` in-register)
+            RP_ijk = _RP_cell(P[i, j, k], P0[i, j, k], div_ijk, Q[i, j, k], ηb[i, j, k], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j, k)
+            RP[i, j, k] = RP_ijk
+            P_num[i, j, k] = γ_eff[i, j, k] * RP_ijk
+        end
+
+        if all((i, j, k) .≤ size(εyz))
+            _dz_vy = @dz(_di_vy, k)
+            _dy_vz = @dy(_di_vz, j)
+            εyz[i, j, k] =
+                0.5 * (
+                _dz_vy * (Vy[i + 1, j, k + 1] - Vy[i + 1, j, k]) +
+                    _dy_vz * (Vz[i + 1, j + 1, k] - Vz[i + 1, j, k])
+            )
+        end
+
+        if all((i, j, k) .≤ size(εxz))
+            _dz_vx = @dz(_di_vx, k)
+            _dx_vz = @dx(_di_vz, i)
+            εxz[i, j, k] =
+                0.5 * (
+                _dz_vx * (Vx[i, j + 1, k + 1] - Vx[i, j + 1, k]) +
+                    _dx_vz * (Vz[i + 1, j + 1, k] - Vz[i, j + 1, k])
+            )
+        end
+
+        if all((i, j, k) .≤ size(εxy))
+            _dy_vx = @dy(_di_vx, j)
+            _dx_vy = @dx(_di_vy, i)
+            εxy[i, j, k] =
+                0.5 * (
+                _dy_vx * (Vx[i, j + 1, k + 1] - Vx[i, j, k + 1]) +
+                    _dx_vy * (Vy[i + 1, j, k + 1] - Vy[i, j, k + 1])
+            )
+        end
+    end
+
+    return nothing
+end
+
 ## RESIDUALS
 
 @parallel_indices (i, j) function compute_PH_residual_V!(
@@ -465,6 +645,179 @@ end
         @inline
         if all(I .≤ size(cV[d]))
             cV[d][I...] = cV_I
+        end
+    end
+
+    return nothing
+end
+
+## DR VELOCITY RESIDUAL + DAMPED UPDATE (fused)
+# Per-index damped pseudo-transient velocity update, shared between the fused residual kernel
+# below and the standalone `update_V_damping_DR_V!`. Returns (dVdτⁿ⁺¹, ΔV) so the caller can
+# update V without re-reading the residual from global memory. GPU-safe (tuple return).
+@inline function damped_update_V(dVdτ, R, α, β, dτ)
+    dVdτ_new = α * dVdτ + R
+    return dVdτ_new, dVdτ_new * β * dτ
+end
+
+# Fuses `compute_DR_residual_V!` (velocity residual R = ∂ⱼτiⱼ − ∂ᵢ(P + P_num + ΔPψ) − ρgᵢ, /Dᵢ)
+# with the damped update of `update_V_damping_DR_V!`. R[I] is written to global memory (needed by
+# the residual norm / λmin) and immediately reused in-register for the velocity update.
+@parallel_indices (i, j) function compute_DR_residual_update_V!(
+        Rx::AbstractArray{T, 2},
+        Ry,
+        Vx,
+        Vy,
+        dVxdτ,
+        dVydτ,
+        P,
+        P_num,
+        ΔPψ,
+        τxx,
+        τyy,
+        τxy,
+        ρgx,
+        ρgy,
+        Dx,
+        Dy,
+        αVx,
+        αVy,
+        βVx,
+        βVy,
+        dτVx,
+        dτVy,
+        _di_center,
+        _di_vertex,
+    ) where {T}
+    Base.@propagate_inbounds @inline av_xa(A) = _av_xa(A, i, j)
+    Base.@propagate_inbounds @inline av_ya(A) = _av_ya(A, i, j)
+
+    @inbounds begin
+        if i ≤ size(Rx, 1) && j ≤ size(Rx, 2)
+            _dx_c = @dx(_di_center, i)
+            _dy_v = @dy(_di_vertex, j)
+            Base.@propagate_inbounds @inline d_xa(A) = _d_xa(A, _dx_c, i, j)
+            Base.@propagate_inbounds @inline d_yi(A) = _d_yi(A, _dy_v, i, j)
+            Rx_ij = (d_xa(τxx) + d_yi(τxy) - d_xa(P) - d_xa(P_num) - d_xa(ΔPψ) - av_xa(ρgx)) / Dx[i, j]
+            Rx[i, j] = Rx_ij
+
+            dVx_new, ΔVx = damped_update_V(dVxdτ[i, j], Rx_ij, αVx[i, j], βVx[i, j], dτVx[i, j])
+            dVxdτ[i, j] = dVx_new
+            Vx[i + 1, j + 1] += ΔVx
+        end
+        if i ≤ size(Ry, 1) && j ≤ size(Ry, 2)
+            _dy_c = @dy(_di_center, j)
+            _dx_v = @dx(_di_vertex, i)
+            Base.@propagate_inbounds @inline d_ya(A) = _d_ya(A, _dy_c, i, j)
+            Base.@propagate_inbounds @inline d_xi(A) = _d_xi(A, _dx_v, i, j)
+            Ry_ij = (d_ya(τyy) + d_xi(τxy) - d_ya(P) - d_ya(P_num) - d_ya(ΔPψ) - av_ya(ρgy)) / Dy[i, j]
+            Ry[i, j] = Ry_ij
+
+            dVy_new, ΔVy = damped_update_V(dVydτ[i, j], Ry_ij, αVy[i, j], βVy[i, j], dτVy[i, j])
+            dVydτ[i, j] = dVy_new
+            Vy[i + 1, j + 1] += ΔVy
+        end
+    end
+
+    return nothing
+end
+
+@parallel_indices (i, j, k) function compute_DR_residual_update_V!(
+        Rx::AbstractArray{T, 3},
+        Ry,
+        Rz,
+        Vx,
+        Vy,
+        Vz,
+        dVxdτ,
+        dVydτ,
+        dVzdτ,
+        P,
+        P_num,
+        ΔPψ,
+        τxx,
+        τyy,
+        τzz,
+        τxy,
+        τxz,
+        τyz,
+        ρgx,
+        ρgy,
+        ρgz,
+        Dx,
+        Dy,
+        Dz,
+        αVx,
+        αVy,
+        αVz,
+        βVx,
+        βVy,
+        βVz,
+        dτVx,
+        dτVy,
+        dτVz,
+        _di_center,
+        _di_vertex,
+    ) where {T}
+
+    Base.@propagate_inbounds @inline d_xa(A, _dx) = _d_xa(A, _dx, i, j, k)
+    Base.@propagate_inbounds @inline d_ya(A, _dy) = _d_ya(A, _dy, i, j, k)
+    Base.@propagate_inbounds @inline d_za(A, _dz) = _d_za(A, _dz, i, j, k)
+    Base.@propagate_inbounds @inline d_xi(A, _dx) = _d_xi(A, _dx, i, j, k)
+    Base.@propagate_inbounds @inline d_yi(A, _dy) = _d_yi(A, _dy, i, j, k)
+    Base.@propagate_inbounds @inline d_zi(A, _dz) = _d_zi(A, _dz, i, j, k)
+    Base.@propagate_inbounds @inline av_x(A) = _av_x(A, i, j, k)
+    Base.@propagate_inbounds @inline av_y(A) = _av_y(A, i, j, k)
+    Base.@propagate_inbounds @inline av_z(A) = _av_z(A, i, j, k)
+
+    @inbounds begin
+        if i ≤ size(Rx, 1) && j ≤ size(Rx, 2) && k ≤ size(Rx, 3)
+            _dx = @dx(_di_center, i)
+            _dy = @dy(_di_vertex, j)
+            _dz = @dz(_di_vertex, k)
+
+            Rx_ijk =
+                (
+                d_xa(τxx, _dx) + d_yi(τxy, _dy) + d_zi(τxz, _dz) -
+                    d_xa(P, _dx) - d_xa(P_num, _dx) - d_xa(ΔPψ, _dx) - av_x(ρgx)
+            ) / Dx[i, j, k]
+            Rx[i, j, k] = Rx_ijk
+
+            dVx_new, ΔVx = damped_update_V(dVxdτ[i, j, k], Rx_ijk, αVx[i, j, k], βVx[i, j, k], dτVx[i, j, k])
+            dVxdτ[i, j, k] = dVx_new
+            Vx[i + 1, j + 1, k + 1] += ΔVx
+        end
+        if i ≤ size(Ry, 1) && j ≤ size(Ry, 2) && k ≤ size(Ry, 3)
+            _dx = @dx(_di_vertex, i)
+            _dy = @dy(_di_center, j)
+            _dz = @dz(_di_vertex, k)
+
+            Ry_ijk =
+                (
+                d_ya(τyy, _dy) + d_xi(τxy, _dx) + d_zi(τyz, _dz) -
+                    d_ya(P, _dy) - d_ya(P_num, _dy) - d_ya(ΔPψ, _dy) - av_y(ρgy)
+            ) / Dy[i, j, k]
+            Ry[i, j, k] = Ry_ijk
+
+            dVy_new, ΔVy = damped_update_V(dVydτ[i, j, k], Ry_ijk, αVy[i, j, k], βVy[i, j, k], dτVy[i, j, k])
+            dVydτ[i, j, k] = dVy_new
+            Vy[i + 1, j + 1, k + 1] += ΔVy
+        end
+        if i ≤ size(Rz, 1) && j ≤ size(Rz, 2) && k ≤ size(Rz, 3)
+            _dx = @dx(_di_vertex, i)
+            _dy = @dy(_di_vertex, j)
+            _dz = @dz(_di_center, k)
+
+            Rz_ijk =
+                (
+                d_za(τzz, _dz) + d_xi(τxz, _dx) + d_yi(τyz, _dy) -
+                    d_za(P, _dz) - d_za(P_num, _dz) - d_za(ΔPψ, _dz) - av_z(ρgz)
+            ) / Dz[i, j, k]
+            Rz[i, j, k] = Rz_ijk
+
+            dVz_new, ΔVz = damped_update_V(dVzdτ[i, j, k], Rz_ijk, αVz[i, j, k], βVz[i, j, k], dτVz[i, j, k])
+            dVzdτ[i, j, k] = dVz_new
+            Vz[i + 1, j + 1, k + 1] += ΔVz
         end
     end
 

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -144,7 +144,7 @@ end
 # numerical pressure P_num = γ_eff * RP in the same pass, reusing the in-register divergence
 # `div_ij` instead of reading ∇V back. RP and P_num are local per-center writes (no halo needed).
 
-function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args, dim)
+function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
     ΔT = haskey(args, :ΔT) ? args.ΔT : nothing
     melt_fraction = haskey(args, :melt_fraction) ? args.melt_fraction : nothing
     @parallel (@idx ni .+ 1) compute_∇V_strain_rate_RP!(
@@ -166,7 +166,10 @@ function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_rati
         melt_fraction,
         dt,
     )
-    return interpolate_shear_ε_to_centers(stokes, dim)
+    # NB: no vertex→center shear-strain interpolation here — ε.*_c is not read inside the DYREL
+    # loop (stress reads ε.xy at vertices; τII viscosity reads τ.xy_c). The center strain arrays
+    # are re-derived once after the loop by shear2center!(stokes.ε).
+    return nothing
 end
 
 @parallel_indices (i, j) function compute_∇V_strain_rate_RP!(

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -140,24 +140,28 @@ end
 end
 
 ## DIVERGENCE + DEVIATORIC STRAIN RATE + PRESSURE RESIDUAL (fused)
-# Same as `compute_∇V_strain_rate!` but additionally evaluates the pressure residual RP and the
-# numerical pressure P_num = γ_eff * RP in the same pass, reusing the in-register divergence
-# `div_ij` instead of reading ∇V back. RP and P_num are local per-center writes (no halo needed).
+# Same as `compute_∇V_strain_rate!` but additionally evaluates the pressure residual RP in the same
+# pass, reusing the in-register divergence `div_ij` instead of reading ∇V back. RP is a local
+# per-center write (no halo needed). The numerical pressure P_num = γ_eff·RP is NOT materialized
+# here — it is folded with the (similarly small) plastic pressure correction ΔPψ into the single
+# `θc` correction array by the stress kernel. Only these two small corrections are summed; the large
+# hydrostatic P is kept separate in the momentum kernel to preserve precision (see
+# compute_stress_viscosity_DRYEL!).
+# NB: ∇V itself is NOT stored here — it is dead inside the DYREL/PH loop (RP is derived from the
+# in-register `div_ij`, and nothing on this path reads ∇V back). The public `stokes.∇V` diagnostic
+# is recomputed once from the converged velocity field after the loop in `_solve_DYREL!`.
 
-function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_ratios, _di, ni, dt, args)
+function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
     ΔT = haskey(args, :ΔT) ? args.ΔT : nothing
     melt_fraction = haskey(args, :melt_fraction) ? args.melt_fraction : nothing
     @parallel (@idx ni .+ 1) compute_∇V_strain_rate_RP!(
-        stokes.∇V,
         @strain(stokes)...,
         @velocity(stokes)...,
         stokes.R.RP,
-        P_num,
         stokes.P,
         stokes.P0,
         stokes.Q,
         dyrel.ηb,
-        dyrel.γ_eff,
         _di.vertex,
         _di.velocity...,
         rheology,
@@ -173,19 +177,16 @@ function compute_∇V_strain_rate_RP!(stokes, dyrel, P_num, rheology, phase_rati
 end
 
 @parallel_indices (i, j) function compute_∇V_strain_rate_RP!(
-        ∇V::AbstractArray{T, 2},
-        εxx,
+        εxx::AbstractArray{T, 2},
         εyy,
         εxy,
         Vx,
         Vy,
         RP,
-        P_num,
         P,
         P0,
         Q,
         ηb,
-        γ_eff,
         _di_vertex,
         _di_vx,
         _di_vy,
@@ -213,7 +214,7 @@ end
             εxy[i, j] = 0.5 * (dVx_dy + dVy_dx)
         end
 
-        if i ≤ size(∇V, 1) && j ≤ size(∇V, 2)
+        if i ≤ size(εxx, 1) && j ≤ size(εxx, 2)
             vx_ne = Vx[i + 1, j + 1]
             vy_ne = Vy[i + 1, j + 1]
             _dx, _dy = @dxi(_di_vertex, i, j)
@@ -221,16 +222,14 @@ end
             dVx_dx = (vx_ne - vx_n) * _dx
             dVy_dy = (vy_ne - vy_e) * _dy
             div_ij = dVx_dx + dVy_dy
-            ∇V[i, j] = div_ij
 
             div_third = div_ij * third
             εxx[i, j] = dVx_dx - div_third
             εyy[i, j] = dVy_dy - div_third
 
-            # fused pressure residual + numerical pressure (reuses `div_ij` in-register)
-            RP_ij = _RP_cell(P[i, j], P0[i, j], div_ij, Q[i, j], ηb[i, j], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j)
-            RP[i, j] = RP_ij
-            P_num[i, j] = γ_eff[i, j] * RP_ij
+            # fused pressure residual (reuses `div_ij` in-register); the numerical pressure
+            # P_num = γ_eff·RP is folded into θc (with ΔPψ) downstream by the stress kernel.
+            RP[i, j] = _RP_cell(P[i, j], P0[i, j], div_ij, Q[i, j], ηb[i, j], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j)
         end
     end
 
@@ -238,8 +237,7 @@ end
 end
 
 @parallel_indices (i, j, k) function compute_∇V_strain_rate_RP!(
-        ∇V::AbstractArray{T, 3},
-        εxx,
+        εxx::AbstractArray{T, 3},
         εyy,
         εzz,
         εyz,
@@ -249,12 +247,10 @@ end
         Vy,
         Vz,
         RP,
-        P_num,
         P,
         P0,
         Q,
         ηb,
-        γ_eff,
         _di_vertex,
         _di_vx,
         _di_vy,
@@ -269,23 +265,21 @@ end
     third = T(1) / T(3)
 
     @inbounds begin
-        if all((i, j, k) .≤ size(∇V))
+        if all((i, j, k) .≤ size(εxx))
             _dx, _dy, _dz = @dxi(_di_vertex, i, j, k)
             dVx_dx = (Vx[i + 1, j + 1, k + 1] - Vx[i, j + 1, k + 1]) * _dx
             dVy_dy = (Vy[i + 1, j + 1, k + 1] - Vy[i + 1, j, k + 1]) * _dy
             dVz_dz = (Vz[i + 1, j + 1, k + 1] - Vz[i + 1, j + 1, k]) * _dz
             div_ijk = dVx_dx + dVy_dy + dVz_dz
-            ∇V[i, j, k] = div_ijk
 
             div_third = div_ijk * third
             εxx[i, j, k] = dVx_dx - div_third
             εyy[i, j, k] = dVy_dy - div_third
             εzz[i, j, k] = dVz_dz - div_third
 
-            # fused pressure residual + numerical pressure (reuses `div_ijk` in-register)
-            RP_ijk = _RP_cell(P[i, j, k], P0[i, j, k], div_ijk, Q[i, j, k], ηb[i, j, k], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j, k)
-            RP[i, j, k] = RP_ijk
-            P_num[i, j, k] = γ_eff[i, j, k] * RP_ijk
+            # fused pressure residual (reuses `div_ijk` in-register); the numerical pressure
+            # P_num = γ_eff·RP is folded into θc (with ΔPψ) downstream by the stress kernel.
+            RP[i, j, k] = _RP_cell(P[i, j, k], P0[i, j, k], div_ijk, Q[i, j, k], ηb[i, j, k], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j, k)
         end
 
         if all((i, j, k) .≤ size(εyz))
@@ -663,9 +657,12 @@ end
     return dVdτ_new, dVdτ_new * β * dτ
 end
 
-# Fuses `compute_DR_residual_V!` (velocity residual R = ∂ⱼτiⱼ − ∂ᵢ(P + P_num + ΔPψ) − ρgᵢ, /Dᵢ)
-# with the damped update of `update_V_damping_DR_V!`. R[I] is written to global memory (needed by
-# the residual norm / λmin) and immediately reused in-register for the velocity update.
+# Fuses `compute_DR_residual_V!` (velocity residual R = ∂ⱼτiⱼ − ∂ᵢ(P + θc) − ρgᵢ, /Dᵢ, where the
+# small pressure correction θc = P_num + ΔPψ is assembled once per iteration by the stress kernel)
+# with the damped update of `update_V_damping_DR_V!`. Folding only the two small corrections (not the
+# large hydrostatic P) collapses three neighbour-stencil reads into two while keeping P differenced
+# at full precision. R[I] is written to global memory (needed by the residual norm / λmin) and
+# immediately reused in-register for the velocity update.
 @parallel_indices (i, j) function compute_DR_residual_update_V!(
         Rx::AbstractArray{T, 2},
         Ry,
@@ -674,8 +671,7 @@ end
         dVxdτ,
         dVydτ,
         P,
-        P_num,
-        ΔPψ,
+        θc,
         τxx,
         τyy,
         τxy,
@@ -701,7 +697,7 @@ end
             _dy_v = @dy(_di_vertex, j)
             Base.@propagate_inbounds @inline d_xa(A) = _d_xa(A, _dx_c, i, j)
             Base.@propagate_inbounds @inline d_yi(A) = _d_yi(A, _dy_v, i, j)
-            Rx_ij = (d_xa(τxx) + d_yi(τxy) - d_xa(P) - d_xa(P_num) - d_xa(ΔPψ) - av_xa(ρgx)) / Dx[i, j]
+            Rx_ij = (d_xa(τxx) + d_yi(τxy) - d_xa(P) - d_xa(θc) - av_xa(ρgx)) / Dx[i, j]
             Rx[i, j] = Rx_ij
 
             dVx_new, ΔVx = damped_update_V(dVxdτ[i, j], Rx_ij, αVx[i, j], βVx[i, j], dτVx[i, j])
@@ -713,7 +709,7 @@ end
             _dx_v = @dx(_di_vertex, i)
             Base.@propagate_inbounds @inline d_ya(A) = _d_ya(A, _dy_c, i, j)
             Base.@propagate_inbounds @inline d_xi(A) = _d_xi(A, _dx_v, i, j)
-            Ry_ij = (d_ya(τyy) + d_xi(τxy) - d_ya(P) - d_ya(P_num) - d_ya(ΔPψ) - av_ya(ρgy)) / Dy[i, j]
+            Ry_ij = (d_ya(τyy) + d_xi(τxy) - d_ya(P) - d_ya(θc) - av_ya(ρgy)) / Dy[i, j]
             Ry[i, j] = Ry_ij
 
             dVy_new, ΔVy = damped_update_V(dVydτ[i, j], Ry_ij, αVy[i, j], βVy[i, j], dτVy[i, j])
@@ -736,8 +732,7 @@ end
         dVydτ,
         dVzdτ,
         P,
-        P_num,
-        ΔPψ,
+        θc,
         τxx,
         τyy,
         τzz,
@@ -782,7 +777,7 @@ end
             Rx_ijk =
                 (
                 d_xa(τxx, _dx) + d_yi(τxy, _dy) + d_zi(τxz, _dz) -
-                    d_xa(P, _dx) - d_xa(P_num, _dx) - d_xa(ΔPψ, _dx) - av_x(ρgx)
+                    d_xa(P, _dx) - d_xa(θc, _dx) - av_x(ρgx)
             ) / Dx[i, j, k]
             Rx[i, j, k] = Rx_ijk
 
@@ -798,7 +793,7 @@ end
             Ry_ijk =
                 (
                 d_ya(τyy, _dy) + d_xi(τxy, _dx) + d_zi(τyz, _dz) -
-                    d_ya(P, _dy) - d_ya(P_num, _dy) - d_ya(ΔPψ, _dy) - av_y(ρgy)
+                    d_ya(P, _dy) - d_ya(θc, _dy) - av_y(ρgy)
             ) / Dy[i, j, k]
             Ry[i, j, k] = Ry_ijk
 
@@ -814,7 +809,7 @@ end
             Rz_ijk =
                 (
                 d_za(τzz, _dz) + d_xi(τxz, _dx) + d_yi(τyz, _dy) -
-                    d_za(P, _dz) - d_za(P_num, _dz) - d_za(ΔPψ, _dz) - av_z(ρgz)
+                    d_za(P, _dz) - d_za(θc, _dz) - av_z(ρgz)
             ) / Dz[i, j, k]
             Rz[i, j, k] = Rz_ijk
 

--- a/test/test_dyrel.jl
+++ b/test/test_dyrel.jl
@@ -37,11 +37,16 @@ end
         @test size(dyrel.dVydτ) == (nx, ny - 1)
         @test size(dyrel.βVx) == (nx - 1, ny)
         @test size(dyrel.αVy) == (nx, ny - 1)
+        @test size(dyrel.P_num) == (nx, ny)
+        @test size(dyrel.Rx0) == (nx - 1, ny)
+        @test size(dyrel.Ry0) == (nx, ny - 1)
+        @test size(dyrel.Rz0) == (1, 1)
         @test dyrel.CFL === 0.5
         @test dyrel.ϵ === 1.0e-7
         @test dyrel.ϵ_vel === 2.0e-7
         @test dyrel.c_fact === 0.25
         @test all(iszero.(dyrel.γ_eff))
+        @test all(iszero.(dyrel.P_num))
         @test all(iszero.(dyrel.Dx)) && all(iszero.(dyrel.Dy))
         @test all(iszero.(dyrel.λmaxVx)) && all(iszero.(dyrel.λmaxVy))
     end
@@ -64,11 +69,16 @@ end
         @test size(dyrel.βVx) == (nx - 1, ny, nz)
         @test size(dyrel.αVy) == (nx, ny - 1, nz)
         @test size(dyrel.cVz) == (nx, ny, nz - 1)
+        @test size(dyrel.P_num) == (nx, ny, nz)
+        @test size(dyrel.Rx0) == (nx - 1, ny, nz)
+        @test size(dyrel.Ry0) == (nx, ny - 1, nz)
+        @test size(dyrel.Rz0) == (nx, ny, nz - 1)
         @test dyrel.CFL === 0.6
         @test dyrel.ϵ === 1.0e-7
         @test dyrel.ϵ_vel === 2.0e-7
         @test dyrel.c_fact === 0.3
         @test all(iszero.(dyrel.γ_eff))
+        @test all(iszero.(dyrel.P_num))
         @test all(iszero.(dyrel.Dz)) && all(iszero.(dyrel.λmaxVz))
 
         # 3-int forwarder

--- a/test/test_dyrel_kernels.jl
+++ b/test/test_dyrel_kernels.jl
@@ -1,0 +1,219 @@
+push!(LOAD_PATH, "..")
+@static if ENV["JULIA_JUSTRELAX_BACKEND"] === "AMDGPU"
+    using AMDGPU
+elseif ENV["JULIA_JUSTRELAX_BACKEND"] === "CUDA"
+    using CUDA
+end
+
+using Test, Suppressor
+using GeoParams
+using JustRelax, JustRelax.JustRelax2D
+import JustRelax.JustRelax3D as JR3
+using ParallelStencil
+
+const backend_JR = @static if ENV["JULIA_JUSTRELAX_BACKEND"] === "AMDGPU"
+    @init_parallel_stencil(AMDGPU, Float64, 3)
+    AMDGPUBackend
+elseif ENV["JULIA_JUSTRELAX_BACKEND"] === "CUDA"
+    @init_parallel_stencil(CUDA, Float64, 3)
+    CUDABackend
+else
+    @init_parallel_stencil(Threads, Float64, 3)
+    CPUBackend
+end
+
+using JustPIC, JustPIC._2D
+const backend_JP = @static if ENV["JULIA_JUSTRELAX_BACKEND"] === "AMDGPU"
+    JustPIC.AMDGPUBackend
+elseif ENV["JULIA_JUSTRELAX_BACKEND"] === "CUDA"
+    CUDABackend
+else
+    JustPIC.CPUBackend
+end
+
+import JustRelax.JustRelax2D: compute_PH_residual_V!, compute_DR_residual_update_V!
+
+@parallel_indices (i, j) function _init_single_phase!(phases)
+    @index phases[1, i, j] = 1.0
+    return nothing
+end
+
+@testset "DYREL kernels" begin
+
+    # ------------------------------------------------------------------ #
+    # Pure, analytic helpers (no grid / rheology needed)
+    # ------------------------------------------------------------------ #
+    @testset "pure helpers" begin
+        # _compute_RP!(P, P0, ∇V, Q, ηb, dt) = -∇V - (P - P0)/ηb + Q/dt
+        P, P0, ∇V, Q, ηb, dt = 3.0, 1.0, 0.5, 0.2, 4.0, 0.25
+        expected = -∇V - (P - P0) / ηb + Q / dt
+        @test JustRelax2D._compute_RP!(P, P0, ∇V, Q, ηb, dt) ≈ expected
+
+        # thermal variant: _compute_RP!(P, P0, ∇V, Q, ΔT, α, ηb, dt)
+        ΔT, α = 10.0, 3.0e-5
+        expected_T = -∇V - (P - P0) / ηb + α * (ΔT / dt) + Q / dt
+        @test JustRelax2D._compute_RP!(P, P0, ∇V, Q, ΔT, α, ηb, dt) ≈ expected_T
+
+        # damped_update_V(dVdτ, R, α, β, dτ) = (dVdτ_new, dVdτ_new*β*dτ)
+        dVdτ, R, a, b, dτ = 2.0, 0.5, 0.9, 0.8, 0.3
+        dVdτ_new, ΔV = JustRelax2D.damped_update_V(dVdτ, R, a, b, dτ)
+        @test dVdτ_new ≈ a * dVdτ + R
+        @test ΔV ≈ (a * dVdτ + R) * b * dτ
+    end
+
+    # ------------------------------------------------------------------ #
+    # Geometric divergence + deviatoric strain rate (2D), driven through
+    # the public wrapper with an analytic pure-strain velocity field:
+    #   Vx = a·x , Vy = b·y  ⇒  ∇V = a+b, εxx = a-(a+b)/3, εyy = b-(a+b)/3, εxy = 0
+    # ------------------------------------------------------------------ #
+    @testset "compute_∇V_strain_rate! 2D" begin
+        nx, ny = 6, 5
+        ni = nx, ny
+        li = 1.0, 1.0
+        grid = Geometry(ni, li; origin = (0.0, 0.0))
+        (; xvi) = grid
+        _di = grid._di
+
+        stokes = StokesArrays(backend_JR, ni)
+        a, b = 2.0, -0.7
+        stokes.V.Vx .= PTArray(backend_JR)([a * x for x in xvi[1], _ in 1:(ny + 2)])
+        stokes.V.Vy .= PTArray(backend_JR)([b * y for _ in 1:(nx + 2), y in xvi[2]])
+
+        JustRelax2D.compute_∇V_strain_rate!(stokes, _di, ni, Val(2))
+
+        div = a + b
+        @test all(Array(stokes.∇V) .≈ div)
+        @test all(Array(stokes.ε.xx) .≈ a - div / 3)
+        @test all(Array(stokes.ε.yy) .≈ b - div / 3)
+        @test all(abs.(Array(stokes.ε.xy)) .< 1.0e-12)
+    end
+
+    # ------------------------------------------------------------------ #
+    # Geometric divergence + deviatoric strain rate (3D):
+    #   Vx = a·x, Vy = b·y, Vz = c·z ⇒ ∇V = a+b+c, εii = di - (a+b+c)/3,
+    #   off-diagonal shear rates = 0
+    # ------------------------------------------------------------------ #
+    @testset "compute_∇V_strain_rate! 3D" begin
+        nx, ny, nz = 5, 4, 3
+        ni = nx, ny, nz
+        li = 1.0, 1.0, 1.0
+        grid = JR3.Geometry(ni, li; origin = (0.0, 0.0, 0.0))
+        (; xvi) = grid
+        _di = grid._di
+
+        stokes = JR3.StokesArrays(backend_JR, ni)
+        a, b, c = 1.5, -0.5, 0.8
+        stokes.V.Vx .= PTArray(backend_JR)([a * x for x in xvi[1], _ in 1:(ny + 2), __ in 1:(nz + 2)])
+        stokes.V.Vy .= PTArray(backend_JR)([b * y for _ in 1:(nx + 2), y in xvi[2], __ in 1:(nz + 2)])
+        stokes.V.Vz .= PTArray(backend_JR)([c * z for _ in 1:(nx + 2), __ in 1:(ny + 2), z in xvi[3]])
+
+        JR3.compute_∇V_strain_rate!(stokes, _di, ni, Val(3))
+
+        div = a + b + c
+        @test all(Array(stokes.∇V) .≈ div)
+        @test all(Array(stokes.ε.xx) .≈ a - div / 3)
+        @test all(Array(stokes.ε.yy) .≈ b - div / 3)
+        @test all(Array(stokes.ε.zz) .≈ c - div / 3)
+        @test all(abs.(Array(stokes.ε.xy)) .< 1.0e-12)
+        @test all(abs.(Array(stokes.ε.xz)) .< 1.0e-12)
+        @test all(abs.(Array(stokes.ε.yz)) .< 1.0e-12)
+    end
+
+    # ------------------------------------------------------------------ #
+    # Fused DYREL kernels (2D). A tiny single-phase, viscoelastic setup
+    # drives the fused strain-rate+RP, stress+τII-viscosity (nonlinear
+    # `linear_viscosity = false` branch), and the residual kernels.
+    # ------------------------------------------------------------------ #
+    @testset "fused kernels 2D" begin
+        nx, ny = 6, 5
+        ni = nx, ny
+        li = 1.0, 1.0
+        grid = Geometry(ni, li; origin = (0.0, 0.0))
+        (; xvi) = grid
+        di = grid.di
+        _di = grid._di
+        dt = 1.0
+
+        el = ConstantElasticity(; G = 1.0, Kb = 5.0)
+        rheology = (
+            SetMaterialParams(;
+                Phase = 1,
+                Density = ConstantDensity(; ρ = 1.0),
+                Gravity = ConstantGravity(; g = 1.0),
+                CompositeRheology = CompositeRheology((LinearViscous(; η = 1.0), el)),
+                Elasticity = el,
+            ),
+        )
+
+        phase_ratios = PhaseRatios(backend_JP, length(rheology), ni)
+        @parallel (@idx ni) _init_single_phase!(phase_ratios.center)
+        @parallel (@idx ni .+ 1) _init_single_phase!(phase_ratios.vertex)
+
+        stokes = StokesArrays(backend_JR, ni)
+        args = (; T = @zeros(ni .+ 2...), P = stokes.P, dt = dt)
+        compute_viscosity!(stokes, phase_ratios, args, rheology, (-Inf, Inf))
+
+        # analytic pure-strain velocity field ⇒ known divergence a+b
+        a, b = 1.3, -0.4
+        stokes.V.Vx .= PTArray(backend_JR)([a * x for x in xvi[1], _ in 1:(ny + 2)])
+        stokes.V.Vy .= PTArray(backend_JR)([b * y for _ in 1:(nx + 2), y in xvi[2]])
+
+        dyrel = DYREL(backend_JR, stokes, rheology, phase_ratios, di, dt; ϵ = 1.0e-6)
+
+        # --- fused divergence + strain rate + pressure residual ---
+        # P0 = P and Q = 0 ⇒ RP = -∇V = -(a+b), independent of ηb
+        stokes.P0 .= stokes.P
+        stokes.Q .= 0.0
+        JustRelax2D.compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
+        @test all(Array(stokes.R.RP) .≈ -(a + b))
+        @test all(Array(stokes.ε.xx) .≈ a - (a + b) / 3)
+
+        # --- fused stress + τII viscosity refresh (nonlinear branch) ---
+        θc = copy(dyrel.P_num)
+        η_before = copy(stokes.viscosity.η)
+        JustRelax2D.compute_stress_viscosity_DRYEL!(
+            stokes, θc, dyrel.γ_eff, rheology, phase_ratios,
+            1.0, dt, 1.0, args, (-Inf, Inf), false,
+        )
+        @test all(isfinite, Array(stokes.viscosity.η))
+        @test all(>(0), Array(stokes.viscosity.η))
+        @test all(isfinite, Array(stokes.viscosity.ηv))
+        # θc assembles the small pressure correction γ_eff·RP + ΔPψ
+        @test Array(θc) ≈ Array(dyrel.γ_eff) .* Array(stokes.R.RP) .+ Array(stokes.ΔPψ)
+
+        # --- Powell-Hestenes velocity residual (no D division: safe) ---
+        ρg = @zeros(ni...), @zeros(ni...)
+        @parallel (@idx ni) compute_PH_residual_V!(
+            stokes.R.Rx, stokes.R.Ry, stokes.P, stokes.ΔPψ,
+            stokes.τ.xx, stokes.τ.yy, stokes.τ.xy, ρg...,
+            _di.center, _di.vertex,
+        )
+        @test all(isfinite, Array(stokes.R.Rx))
+        @test all(isfinite, Array(stokes.R.Ry))
+
+        # --- fused DR residual + damped velocity update ---
+        # D = 1, β = 0 ⇒ ΔV = 0 (velocity unchanged), residuals finite
+        dyrel.Dx .= 1.0; dyrel.Dy .= 1.0
+        dyrel.βVx .= 0.0; dyrel.βVy .= 0.0
+        dyrel.αVx .= 0.0; dyrel.αVy .= 0.0
+        dyrel.dτVx .= 1.0; dyrel.dτVy .= 1.0
+        Vx_before = copy(stokes.V.Vx)
+        Vy_before = copy(stokes.V.Vy)
+        @parallel (@idx ni) compute_DR_residual_update_V!(
+            stokes.R.Rx, stokes.R.Ry,
+            stokes.V.Vx, stokes.V.Vy,
+            dyrel.dVxdτ, dyrel.dVydτ,
+            stokes.P, θc,
+            stokes.τ.xx, stokes.τ.yy, stokes.τ.xy,
+            ρg...,
+            dyrel.Dx, dyrel.Dy,
+            dyrel.αVx, dyrel.αVy,
+            dyrel.βVx, dyrel.βVy,
+            dyrel.dτVx, dyrel.dτVy,
+            _di.center, _di.vertex,
+        )
+        @test all(isfinite, Array(stokes.R.Rx))
+        @test Array(stokes.V.Vx) == Array(Vx_before)
+        @test Array(stokes.V.Vy) == Array(Vy_before)
+    end
+end

--- a/test/test_dyrel_kernels.jl
+++ b/test/test_dyrel_kernels.jl
@@ -8,17 +8,16 @@ end
 using Test, Suppressor
 using GeoParams
 using JustRelax, JustRelax.JustRelax2D
-import JustRelax.JustRelax3D as JR3
 using ParallelStencil
 
 const backend_JR = @static if ENV["JULIA_JUSTRELAX_BACKEND"] === "AMDGPU"
-    @init_parallel_stencil(AMDGPU, Float64, 3)
+    @init_parallel_stencil(AMDGPU, Float64, 2)
     AMDGPUBackend
 elseif ENV["JULIA_JUSTRELAX_BACKEND"] === "CUDA"
-    @init_parallel_stencil(CUDA, Float64, 3)
+    @init_parallel_stencil(CUDA, Float64, 2)
     CUDABackend
 else
-    @init_parallel_stencil(Threads, Float64, 3)
+    @init_parallel_stencil(Threads, Float64, 2)
     CPUBackend
 end
 
@@ -31,7 +30,13 @@ else
     JustPIC.CPUBackend
 end
 
-import JustRelax.JustRelax2D: compute_PH_residual_V!, compute_DR_residual_update_V!
+const JR2K = @static if ENV["JULIA_JUSTRELAX_BACKEND"] === "AMDGPU"
+    Base.get_extension(JustRelax, :JustRelaxAMDGPUExt).JustRelax2D
+elseif ENV["JULIA_JUSTRELAX_BACKEND"] === "CUDA"
+    Base.get_extension(JustRelax, :JustRelaxCUDAExt).JustRelax2D
+else
+    JustRelax.JustRelax2D
+end
 
 @parallel_indices (i, j) function _init_single_phase!(phases)
     @index phases[1, i, j] = 1.0
@@ -79,44 +84,13 @@ end
         stokes.V.Vx .= PTArray(backend_JR)([a * x for x in xvi[1], _ in 1:(ny + 2)])
         stokes.V.Vy .= PTArray(backend_JR)([b * y for _ in 1:(nx + 2), y in xvi[2]])
 
-        JustRelax2D.compute_∇V_strain_rate!(stokes, _di, ni, Val(2))
+        JR2K.compute_∇V_strain_rate!(stokes, _di, ni, Val(2))
 
         div = a + b
         @test all(Array(stokes.∇V) .≈ div)
         @test all(Array(stokes.ε.xx) .≈ a - div / 3)
         @test all(Array(stokes.ε.yy) .≈ b - div / 3)
         @test all(abs.(Array(stokes.ε.xy)) .< 1.0e-12)
-    end
-
-    # ------------------------------------------------------------------ #
-    # Geometric divergence + deviatoric strain rate (3D):
-    #   Vx = a·x, Vy = b·y, Vz = c·z ⇒ ∇V = a+b+c, εii = di - (a+b+c)/3,
-    #   off-diagonal shear rates = 0
-    # ------------------------------------------------------------------ #
-    @testset "compute_∇V_strain_rate! 3D" begin
-        nx, ny, nz = 5, 4, 3
-        ni = nx, ny, nz
-        li = 1.0, 1.0, 1.0
-        grid = JR3.Geometry(ni, li; origin = (0.0, 0.0, 0.0))
-        (; xvi) = grid
-        _di = grid._di
-
-        stokes = JR3.StokesArrays(backend_JR, ni)
-        a, b, c = 1.5, -0.5, 0.8
-        stokes.V.Vx .= PTArray(backend_JR)([a * x for x in xvi[1], _ in 1:(ny + 2), __ in 1:(nz + 2)])
-        stokes.V.Vy .= PTArray(backend_JR)([b * y for _ in 1:(nx + 2), y in xvi[2], __ in 1:(nz + 2)])
-        stokes.V.Vz .= PTArray(backend_JR)([c * z for _ in 1:(nx + 2), __ in 1:(ny + 2), z in xvi[3]])
-
-        JR3.compute_∇V_strain_rate!(stokes, _di, ni, Val(3))
-
-        div = a + b + c
-        @test all(Array(stokes.∇V) .≈ div)
-        @test all(Array(stokes.ε.xx) .≈ a - div / 3)
-        @test all(Array(stokes.ε.yy) .≈ b - div / 3)
-        @test all(Array(stokes.ε.zz) .≈ c - div / 3)
-        @test all(abs.(Array(stokes.ε.xy)) .< 1.0e-12)
-        @test all(abs.(Array(stokes.ε.xz)) .< 1.0e-12)
-        @test all(abs.(Array(stokes.ε.yz)) .< 1.0e-12)
     end
 
     # ------------------------------------------------------------------ #
@@ -164,14 +138,14 @@ end
         # P0 = P and Q = 0 ⇒ RP = -∇V = -(a+b), independent of ηb
         stokes.P0 .= stokes.P
         stokes.Q .= 0.0
-        JustRelax2D.compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
+        JR2K.compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
         @test all(Array(stokes.R.RP) .≈ -(a + b))
         @test all(Array(stokes.ε.xx) .≈ a - (a + b) / 3)
 
         # --- fused stress + τII viscosity refresh (nonlinear branch) ---
         θc = copy(dyrel.P_num)
         η_before = copy(stokes.viscosity.η)
-        JustRelax2D.compute_stress_viscosity_DRYEL!(
+        JR2K.compute_stress_viscosity_DRYEL!(
             stokes, θc, dyrel.γ_eff, rheology, phase_ratios,
             1.0, dt, 1.0, args, (-Inf, Inf), false,
         )
@@ -183,7 +157,7 @@ end
 
         # --- Powell-Hestenes velocity residual (no D division: safe) ---
         ρg = @zeros(ni...), @zeros(ni...)
-        @parallel (@idx ni) compute_PH_residual_V!(
+        @parallel (@idx ni) JR2K.compute_PH_residual_V!(
             stokes.R.Rx, stokes.R.Ry, stokes.P, stokes.ΔPψ,
             stokes.τ.xx, stokes.τ.yy, stokes.τ.xy, ρg...,
             _di.center, _di.vertex,
@@ -199,7 +173,7 @@ end
         dyrel.dτVx .= 1.0; dyrel.dτVy .= 1.0
         Vx_before = copy(stokes.V.Vx)
         Vy_before = copy(stokes.V.Vy)
-        @parallel (@idx ni) compute_DR_residual_update_V!(
+        @parallel (@idx ni) JR2K.compute_DR_residual_update_V!(
             stokes.R.Rx, stokes.R.Ry,
             stokes.V.Vx, stokes.V.Vy,
             dyrel.dVxdτ, dyrel.dVydτ,


### PR DESCRIPTION
### Whats the purpose of this PR?
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other, please explain

**Describe it in more detail below:**

This PR optimizes the DYREL solver inner loop by fusing several hot kernels that were previously launched as separate passes over the same fields.

Main changes:
- Fuse divergence, deviatoric strain-rate, pressure residual, and numerical pressure updates into `compute_∇V_strain_rate_RP!` for both 2D and 3D.
- Add `_RP_cell` so the fused strain-rate kernel preserves the existing pressure residual behavior for plain, thermal, and melt-fraction cases.
- Fuse deviatoric stress and τII-based viscosity refresh into `compute_stress_viscosity_DRYEL!`, reusing freshly computed stress values before they round-trip through memory.
- Fuse DR velocity residual computation with the damped pseudo-transient velocity update via `compute_DR_residual_update_V!`.
- Drop the dead `∇V` store inside the DYREL/PH inner loop (it is not read there) and recompute the `∇V` diagnostic once after convergence.
- Fold the small pressure corrections into a single scratch array `θc = γ_eff·RP + ΔPψ`, assembled by the stress kernel and read by the momentum kernel alongside the separately-differenced hydrostatic `P`. This removes the separately materialized `P_num` array. The large `P` is kept out of the fold on purpose: summing it with the small corrections before differencing loses low-order bits of the convergence-driving term.
- Preallocate `P_num` (reused as the `θc` scratch) and velocity residual-history scratch arrays in `DYREL` instead of allocating them on every solve.
- Avoid copying previous residuals on iterations where `compute_λminV!` is not called.
- Batch vertex stress halos, and include vertex viscosity in the same exchange for nonlinear viscosity, to preserve the original stress-halo-viscosity consistency across ranks.

Performance impact:
- Removes separate global-memory passes for pressure residual calculation, `P_num` assignment, τII viscosity refresh, and DR velocity damping/update.
- Removes one array write per inner iteration (dead `∇V` store) and one stencil read in the momentum residual (`P + θc` instead of `P + P_num + ΔPψ`), and drops the `P_num` materialization entirely.
- Reduces kernel launch overhead in every DYREL iteration by doing more work per pass over the same indices.
- Reuses in-register divergence, stress, and residual values instead of reading them back from arrays in follow-up kernels.
- Removes per-solve allocations for numerical pressure and residual-history scratch fields.
- Reduces MPI halo exchange overhead by grouping vertex stress fields, and nonlinear vertex viscosity, into one halo update.
- Skips residual history copies on non-output iterations, reducing unnecessary memory traffic when `nout > 1`.

Performance check:

Nonlinear 2D DYREL power-law shear-band benchmark based on `miniapps/DYREL2D/shear_band/ShearBand2D_PowerLaw_DYREL.jl` (plotting/file I/O removed).
The benchmark times only `solve_DYREL!`, on `CPUBackend` with one Julia thread and one MPI rank, over a fixed budget of 200 DYREL iterations (one Powell–Hestenes sweep, `nout = 100`), rebuilding a fresh problem state per sample. Both branches were measured with the same harness and the same local `Manifest.toml`.

Reported numbers are the **minimum** solve time over the samples. On the M-series laptop used here the median is corrupted by thermal throttling (per-sample spreads up to ~18% at 128², larger at 256²), so the least-throttled sample is the more reliable estimate of compute cost; the min values are stable across repeated runs.

| Grid | DYREL iterations | Samples | `origin/main` min | PR min | Speedup | Time reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 64x64 | 200 | 5–7 | 0.105469 s | 0.084020 s | 1.26x | 20.3% |
| 128x128 | 200 | 5–7 | 0.318044 s | 0.280867 s | 1.13x | 11.7% |
| 256x256 | 200 | 3–7 | 1.209531 s | 1.066246 s | 1.13x | 11.8% |

The relative gain is largest at 64x64, where kernel-launch and per-pass overhead dominate and the fusion removes the most passes; at 128x128 and 256x256 it settles at ~1.13x as the work becomes more memory-bandwidth bound. The `∇V`/`θc` changes are convergence- and CPU-neutral (identical iteration counts, wall time within noise); their payoff is reduced GPU memory traffic and is expected to show on the CUDA/AMDGPU backends.

Benchmark command shape:
`JULIA_NUM_THREADS=1 JR_DYREL_BENCH_NX=<N> JR_DYREL_BENCH_NY=<N> JR_DYREL_BENCH_ITERS=200 JR_DYREL_BENCH_WARMUPS=1 JR_DYREL_BENCH_SAMPLES=<3–7> julia --project=. -t 1 dyrel_shearband_perf.jl`

Validation:
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `JULIA_JUSTRELAX_BACKEND=CPU julia --project=. test/test_dyrel.jl` (`67/67` passing)
- `test/test_shearband2D_DYREL.jl` (`5/5`) and `test/test_shearband2D_DPCap_DYREL.jl` (`7/7`) passing

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
