### PR TITLE
[IMPROVEMENT] Recompute DYREL pressure residual before pressure update

### DIFF
--- a/miniapps/DYREL2D/sinking_block/SinkingBlock2D.jl
+++ b/miniapps/DYREL2D/sinking_block/SinkingBlock2D.jl
@@ -144,8 +144,8 @@ function sinking_block2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", t
             dt,
             igg;
             kwargs = (;
-                verbose_PH = false,
-                verbose_DR = false,
+                verbose_PH = true,
+                verbose_DR = true,
                 iterMax = 50.0e3,
                 nout = 10,
                 rel_drop = 1.0e-2,
@@ -202,7 +202,3 @@ else
 end
 
 sinking_block2D(igg; ar = ar, nx = nx, ny = ny);
-# extrema(stokes.∇V) = (-1.9891239712950583e-16, 1.3077805713409153e-15)
-
-# dyrel.γ_eff
-# γ_eff

--- a/src/DYREL/solver.jl
+++ b/src/DYREL/solver.jl
@@ -124,7 +124,8 @@ function _solve_DYREL!(
         update_ρg!(ρg, phase_ratios, rheology, args)
 
         # compute divergence, deviatoric strain rate and pressure residual in one pass
-        compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
+        # isone(itPH) &&
+        compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, true)
 
         # compute deviatoric stress, refresh τII viscosity, and assemble θc = γ_eff·RP + ΔPψ in one pass
         compute_stress_viscosity_DRYEL!(stokes, θc, dyrel.γ_eff, rheology, phase_ratios, λ_relaxation_PH, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
@@ -190,7 +191,7 @@ function _solve_DYREL!(
             iszero(iter % nout) && foreach(copyto!, residuals0, residuals)
 
             # compute divergence, deviatoric strain rate and pressure residual in one pass
-            compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
+            compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, true)
 
             # Deviatoric stress, τII viscosity refresh, and θc = γ_eff·RP + ΔPψ assembly in one pass
             compute_stress_viscosity_DRYEL!(stokes, θc, dyrel.γ_eff, rheology, phase_ratios, λ_relaxation_DR, dt, viscosity_relaxation, args, viscosity_cutoff, linear_viscosity)
@@ -258,6 +259,7 @@ function _solve_DYREL!(
         end
 
         # update pressure
+        compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, false)
         @. stokes.P += dyrel.γ_eff .* stokes.R.RP
 
         iter > total_iterMax && break

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -220,11 +220,11 @@ end
             vx_ne = Vx[i + 1, j + 1]
             vy_ne = Vy[i + 1, j + 1]
             _dx, _dy = @dxi(_di_vertex, i, j)
-            
+
             dVx_dx = (vx_ne - vx_n) * _dx
             dVy_dy = (vy_ne - vy_e) * _dy
             div_ij = dVx_dx + dVy_dy
-            
+
             if do_strain_rate
                 div_third = div_ij * third
                 εxx[i, j] = dVx_dx - div_third

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -151,7 +151,7 @@ end
 # in-register `div_ij`, and nothing on this path reads ∇V back). The public `stokes.∇V` diagnostic
 # is recomputed once from the converged velocity field after the loop in `_solve_DYREL!`.
 
-function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args)
+function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, do_strain_rate)
     ΔT = haskey(args, :ΔT) ? args.ΔT : nothing
     melt_fraction = haskey(args, :melt_fraction) ? args.melt_fraction : nothing
     @parallel (@idx ni .+ 1) compute_∇V_strain_rate_RP!(
@@ -169,6 +169,7 @@ function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di
         ΔT,
         melt_fraction,
         dt,
+        do_strain_rate
     )
     # NB: no vertex→center shear-strain interpolation here — ε.*_c is not read inside the DYREL
     # loop (stress reads ε.xy at vertices; τII viscosity reads τ.xy_c). The center strain arrays
@@ -195,6 +196,7 @@ end
         ΔT,
         melt_fraction,
         dt,
+        do_strain_rate
     ) where {T}
 
     third = T(1) / T(3)
@@ -205,7 +207,7 @@ end
         vy_w = Vy[i, j]
         vy_e = Vy[i + 1, j]
 
-        if i ≤ size(εxy, 1) && j ≤ size(εxy, 2)
+        if do_strain_rate && i ≤ size(εxy, 1) && j ≤ size(εxy, 2)
             _dy_vx = @dy(_di_vx, j)
             _dx_vy = @dx(_di_vy, i)
 
@@ -218,15 +220,16 @@ end
             vx_ne = Vx[i + 1, j + 1]
             vy_ne = Vy[i + 1, j + 1]
             _dx, _dy = @dxi(_di_vertex, i, j)
-
+            
             dVx_dx = (vx_ne - vx_n) * _dx
             dVy_dy = (vy_ne - vy_e) * _dy
             div_ij = dVx_dx + dVy_dy
-
-            div_third = div_ij * third
-            εxx[i, j] = dVx_dx - div_third
-            εyy[i, j] = dVy_dy - div_third
-
+            
+            if do_strain_rate
+                div_third = div_ij * third
+                εxx[i, j] = dVx_dx - div_third
+                εyy[i, j] = dVy_dy - div_third
+            end
             # fused pressure residual (reuses `div_ij` in-register); the numerical pressure
             # P_num = γ_eff·RP is folded into θc (with ΔPψ) downstream by the stress kernel.
             RP[i, j] = _RP_cell(P[i, j], P0[i, j], div_ij, Q[i, j], ηb[i, j], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j)
@@ -260,6 +263,7 @@ end
         ΔT,
         melt_fraction,
         dt,
+        do_strain_rate,
     ) where {T}
 
     third = T(1) / T(3)
@@ -272,17 +276,18 @@ end
             dVz_dz = (Vz[i + 1, j + 1, k + 1] - Vz[i + 1, j + 1, k]) * _dz
             div_ijk = dVx_dx + dVy_dy + dVz_dz
 
-            div_third = div_ijk * third
-            εxx[i, j, k] = dVx_dx - div_third
-            εyy[i, j, k] = dVy_dy - div_third
-            εzz[i, j, k] = dVz_dz - div_third
-
+            if do_strain_rate
+                div_third = div_ijk * third
+                εxx[i, j, k] = dVx_dx - div_third
+                εyy[i, j, k] = dVy_dy - div_third
+                εzz[i, j, k] = dVz_dz - div_third
+            end
             # fused pressure residual (reuses `div_ijk` in-register); the numerical pressure
             # P_num = γ_eff·RP is folded into θc (with ΔPψ) downstream by the stress kernel.
             RP[i, j, k] = _RP_cell(P[i, j, k], P0[i, j, k], div_ijk, Q[i, j, k], ηb[i, j, k], dt, rheology, phase_ratio, ΔT, melt_fraction, i, j, k)
         end
 
-        if all((i, j, k) .≤ size(εyz))
+        if do_strain_rate && all((i, j, k) .≤ size(εyz))
             _dz_vy = @dz(_di_vy, k)
             _dy_vz = @dy(_di_vz, j)
             εyz[i, j, k] =
@@ -292,7 +297,7 @@ end
             )
         end
 
-        if all((i, j, k) .≤ size(εxz))
+        if do_strain_rate && all((i, j, k) .≤ size(εxz))
             _dz_vx = @dz(_di_vx, k)
             _dx_vz = @dx(_di_vz, i)
             εxz[i, j, k] =
@@ -302,7 +307,7 @@ end
             )
         end
 
-        if all((i, j, k) .≤ size(εxy))
+        if do_strain_rate && all((i, j, k) .≤ size(εxy))
             _dy_vx = @dy(_di_vx, j)
             _dx_vy = @dx(_di_vy, i)
             εxy[i, j, k] =

--- a/src/DYREL/velocity_kernels.jl
+++ b/src/DYREL/velocity_kernels.jl
@@ -151,7 +151,7 @@ end
 # in-register `div_ij`, and nothing on this path reads ∇V back). The public `stokes.∇V` diagnostic
 # is recomputed once from the converged velocity field after the loop in `_solve_DYREL!`.
 
-function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, do_strain_rate)
+function compute_∇V_strain_rate_RP!(stokes, dyrel, rheology, phase_ratios, _di, ni, dt, args, do_strain_rate = true)
     ΔT = haskey(args, :ΔT) ? args.ΔT : nothing
     melt_fraction = haskey(args, :melt_fraction) ? args.melt_fraction : nothing
     @parallel (@idx ni .+ 1) compute_∇V_strain_rate_RP!(


### PR DESCRIPTION
### Whats the purpose of this PR?
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other, please explain

**Describe it in more detail below:**

This PR recomputes the DYREL pressure residual immediately before applying the pressure update, so the update uses residuals from the current solver state. By doing so, it (very slightly) reduces the amount of PT iterations.

It threads a `do_strain_rate` flag through `compute_∇V_strain_rate_RP!`, allowing the solver to refresh pressure residuals without also rewriting strain-rate fields on that final pre-update pass. The sinking-block DYREL miniapp is updated to emit PH/DR convergence output while exercising the revised solver behavior.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [x] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
