### PR TITLE
[IMPROVEMENT] Scale DYREL penalty by local viscosity

### DIFF
--- a/src/DYREL/constructors.jl
+++ b/src/DYREL/constructors.jl
@@ -213,8 +213,8 @@ Computes the bulk viscosity `ηb` and the effective penalty parameter `γ_eff`.
    - Otherwise `ηb = Kb * dt`.
 
 2. **Penalty Parameter (`γ_eff`)**: A combination of numerical (`γ_num`) and physical (`γ_phy`) penalty terms.
-   - `γ_num = γfact * η_mean`
-   - `γ_phy = Kb` (or related term)
+   - `γ_num = γfact * η` (local viscosity; falls back to `η_mean` where `η` is infinite)
+   - `γ_phy = Kb * dt` (or `γ_num` where `Kb` is infinite)
    - `γ_eff = (γ_phy * γ_num) / (γ_phy + γ_num)`
 
 # Arguments
@@ -229,21 +229,25 @@ This function parallelizes the computation across grid cells.
 """
 function compute_bulk_viscosity_and_penalty!(dyrel, stokes, rheology, phase_ratios, γfact, dt)
     ni = size(stokes.P)
-    @parallel (@idx ni) compute_bulk_viscosity_and_penalty!(dyrel.ηb, dyrel.γ_eff, rheology, phase_ratios.center, mean(stokes.viscosity.η[.!isinf.(stokes.viscosity.η)]), γfact, dt)
+    @parallel (@idx ni) compute_bulk_viscosity_and_penalty!(dyrel.ηb, dyrel.γ_eff, rheology, phase_ratios.center, stokes.viscosity.η, mean(stokes.viscosity.η[.!isinf.(stokes.viscosity.η)]), γfact, dt)
     return nothing
 end
 
 
-@parallel_indices (I...) function compute_bulk_viscosity_and_penalty!(ηb, γ_eff, rheology, phase_ratios_center, η_mean, γfact, dt)
+@parallel_indices (I...) function compute_bulk_viscosity_and_penalty!(ηb, γ_eff, rheology, phase_ratios_center, η, η_mean, γfact, dt)
 
     # bulk viscosity
     ratios = @inbounds @cell phase_ratios_center[I...]
     Kbdt = fn_ratio(get_bulk_modulus, rheology, ratios) * dt
     ηb[I...] = Kbdt
 
-    # penalty parameter factor
-    γ_num = γfact * η_mean
-    γ_phy = isinf(Kbdt) ? γfact * η_mean : Kbdt
+    # penalty parameter: scaled by the *local* viscosity so that γ_eff/η stays O(γfact)
+    # everywhere. A global mean-viscosity scaling over-penalizes the low-viscosity regions
+    # of high-contrast problems, which stiffens the velocity pseudo-transient solve there
+    # and stalls convergence of the last Powell-Hestenes steps.
+    η_local = η[I...]
+    γ_num = γfact * (isinf(η_local) ? η_mean : η_local)
+    γ_phy = isinf(Kbdt) ? γ_num : Kbdt
     γ_eff[I...] = γ_phy * γ_num / (γ_phy + γ_num)
 
     return nothing
@@ -258,7 +262,7 @@ function compute_bulk_viscosity_and_penalty!(dyrel, stokes, rheology, phase_rati
     return nothing
 end
 
-@parallel_indices (I...) function compute_bulk_viscosity_and_penalty!(ηb, γ_eff, rheology, phase_ratios_center, ϕ, η_mean, γfact, dt)
+@parallel_indices (I...) function compute_bulk_viscosity_and_penalty!(ηb, γ_eff, rheology, phase_ratios_center, ϕ::JustRelax.RockRatio, η_mean, γfact, dt)
 
     if isvalid_c(ϕ, I...)
         # bulk viscosity


### PR DESCRIPTION
### Whats the purpose of this PR?
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other, please explain

**Describe it in more detail below:**

Convergence improvement for the DYREL solver. The numerical part of the augmented-Lagrangian penalty now scales with the *local* viscosity, `γ_num = γfact·η[I]` (falling back to the mean viscosity where `η` is `Inf`), instead of the global `mean(η)`, and `γ_phy` falls back to `γ_num` where the bulk modulus is infinite. This keeps `γ_eff/η = O(γfact)` everywhere: a global mean-viscosity scaling over-penalizes the low-viscosity regions of high-contrast problems, which stiffens the velocity pseudo-transient solve there and stalls the last Powell–Hestenes steps.

The `RockRatio` variant of the kernel (free-surface / sticky-air setups) keeps the mean-viscosity scaling and is unaffected.

**Convergence A/B vs `main`** (CPU, only this change differing; nonlinear 2D miniapps):

| Case | `main` (mean η) | this PR (local η) |
|---|---|---|
| `Shearheating2D_DYREL` (dislocation creep, 62², 1 step) | 7,000 iters, 6 PH steps | **6,400 iters (−9%)**, 6 PH steps |
| `ShearBand2D_DYREL` (viscoelastoplastic, 128×256, 10 steps) | 31,550 iters total | 31,550 iters total (bit-identical solution) |

Solutions agree between the two definitions (shear heating: ‖Vx‖ to ~1e-5 relative, P to ~0.3%; shear band: identical to the last bit). The shear band case is insensitive by construction: with `Kb = 5` and `dt = 1/6`, `γ_phy = Kb·dt ≪ γ_num`, so the harmonic mean gives `γ_eff ≈ Kb·dt` under either scaling — a useful check that compressible setups are unaffected.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [x] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)