### PR TITLE
Fix contributing template links at the source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 [JustRelax.jl](https://github.com/PTsolvers/JustRelax.jl) is an open-source project and we are very happy to accept contributions
-from the community. Please feel free to open [Issues](https://github.com/PTsolvers/JustRelax.jl/issues/new) (issue templeates in [here](https://github.com/PTsolvers/JustRelax.jl/tree/adm/JOSS/.github/ISSUE_TEMPLATE)) or submit [Pull Requests](https://github.com/PTsolvers/JustRelax.jl/pulls) (PR templeate in [here](https://github.com/PTsolvers/JustRelax.jl/blob/adm/JOSS/.github/PULL_REQUEST_TEMPLATE.md)) to the `main` branch with your contribution. For planned large contributions, it is often
+from the community. Please feel free to open [Issues](https://github.com/PTsolvers/JustRelax.jl/issues/new) (issue templates in [here](https://github.com/PTsolvers/JustRelax.jl/tree/main/.github/ISSUE_TEMPLATE)) or submit [Pull Requests](https://github.com/PTsolvers/JustRelax.jl/pulls) (PR template in [here](https://github.com/PTsolvers/JustRelax.jl/blob/main/.github/PULL_REQUEST_TEMPLATE.md)) to the `main` branch with your contribution. For planned large contributions, it is often
 beneficial to get in contact with one of the principal developers first (see
 [AUTHORS.md](AUTHORS.md)).
 

--- a/docs/src/man/contributing.md
+++ b/docs/src/man/contributing.md
@@ -5,7 +5,7 @@ EditURL = "https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md"
 # Contributing
 
 [JustRelax.jl](https://github.com/PTsolvers/JustRelax.jl) is an open-source project and we are very happy to accept contributions
-from the community. Please feel free to open [Issues](https://github.com/PTsolvers/JustRelax.jl/issues/new) (issue templates in [here](https://github.com/PTsolvers/JustRelax.jl/blob/main/.github/ISSUE_TEMPLATE)) or submit [Pull Requests](https://github.com/PTsolvers/JustRelax.jl/pulls) (PR templeate in [here](https://github.com/PTsolvers/JustRelax.jl/blob/main.github/PULL_REQUEST_TEMPLATE.md)) to the `main` branch with your contribution. For planned large contributions, it is often
+from the community. Please feel free to open [Issues](https://github.com/PTsolvers/JustRelax.jl/issues/new) (issue templates in [here](https://github.com/PTsolvers/JustRelax.jl/tree/main/.github/ISSUE_TEMPLATE)) or submit [Pull Requests](https://github.com/PTsolvers/JustRelax.jl/pulls) (PR template in [here](https://github.com/PTsolvers/JustRelax.jl/blob/main/.github/PULL_REQUEST_TEMPLATE.md)) to the `main` branch with your contribution. For planned large contributions, it is often
 beneficial to get in contact with one of the principal developers first (see
 [Authors](@ref)).
 


### PR DESCRIPTION
`docs/src/man/contributing.md` is generated from the repo-root `CONTRIBUTING.md` by `docs/make.jl`, so the fix that was applied to the generated page never took effect — every build overwrites it. The published Contributing page still shows "templeates" and links into the `adm/JOSS` branch.

- **`CONTRIBUTING.md`** — typos fixed, both template links moved from `adm/JOSS` to `main`.
- **`docs/src/man/contributing.md`** — regenerated with make.jl's own transform, so source and page agree and it stops showing up dirty after a local build.

Regenerating also clears two bugs in the committed page: `blob/` pointing at the `ISSUE_TEMPLATE` directory (GitHub 404s on that — now `tree/`), and a missing slash in `blob/main.github/PULL_REQUEST_TEMPLATE.md`. Both targets exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
