### PR TITLE
Sync docs examples with the current API

### DIFF
--- a/docs/src/man/Blankenbach.md
+++ b/docs/src/man/Blankenbach.md
@@ -14,7 +14,7 @@ const backend_JR = CPUBackend
 For this benchmark we will use particles to track the advection of the material phases and their information. For this, we will use [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl)
 ```julia
 using JustPIC, JustPIC._2D
-const backend = JustPIC.CPUBackend # Options: CPUBackend, CUDABackend, AMDGPUBackend
+const backend_JP = JustPIC.CPUBackend # Options: CPUBackend, CUDABackend, AMDGPUBackend
 ```
 
 We will also use [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) to write some device-agnostic helper functions:
@@ -33,6 +33,7 @@ using GeoParams
 ```julia
 nx = ny      = 51                       # number of cells per dimension
 nit          = 6e3
+ar           = 1                        # aspect ratio
 igg          = IGG(
     init_global_grid(nx, ny, 1; init_MPI= true)...
 )                                       # initialize MPI grid
@@ -68,9 +69,9 @@ nxcell              = 24 # initial number of perticles per cell
 max_xcell           = 35 # maximum number of perticles per cell
 min_xcell           = 12 # minimum number of perticles per cell
 particles           = init_particles(
-    backend, nxcell, max_xcell, min_xcell, grid.xi_vel...
+    backend_JP, nxcell, max_xcell, min_xcell, grid.xi_vel...
 ) # particles object
-subgrid_arrays      = SubgridDiffusionCellArrays(particles) # arrays needed for subgrid diffusion
+subgrid_arrays      = SubgridDiffusionCellArrays(particles; loc = :center) # arrays needed for subgrid diffusion
 ```
 
 and we want to keep track of the temperature `pT`, temperature of the previous time step `pT0`, and material phase `pPhase`:
@@ -108,18 +109,18 @@ end
 init_phases!(pPhases, particles)
 ```
 
-or we can use the alternative one-liners
+or, since `particles.index` is a `Bool` cell array flagging the occupied slots, we can use the alternative one-liners
 ```julia
-@views pPhases.data[!isnan.(particles.index.data)] .= 1.0
+@views pPhases.data[particles.index.data] .= 1.0
 ```
 or
 ```julia
-map!(x -> isnan(x) ? NaN : 1.0, pPhases.data, particles.index.data)
+map!(x -> x ? 1.0 : 0.0, pPhases.data, particles.index.data)
 ```
 
 and finally we need the phase ratios at the cell centers:
 ```julia
-phase_ratios = PhaseRatios(backend, length(rheology), ni)
+phase_ratios = PhaseRatios(backend_JP, length(rheology), ni)
 update_phase_ratios!(phase_ratios, particles, pPhases)
 ```
 
@@ -138,33 +139,34 @@ thermal = ThermalArrays(backend_JR, ni)
 ### Initialize thermal profile and viscosity fields
 
 To initialize the thermal profile we use [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) again
+`thermal.T` is cell-centered with one ring of ghost nodes, so the kernel writes with an offset of one instead of slicing (a slice would be a copy, and the result would be discarded):
 ```julia
 @parallel_indices (i, j) function init_T!(T, y)
-    T[i, j] = 1 - y[j]
+    T[i + 1, j + 1] = 1 - y[j]
     return nothing
 end
 
-@parallel (@idx ni) init_T!((thermal.T[2:end-1, 2:end-1]), xci[2]) # physical cell centers
+@parallel (@idx ni) init_T!(thermal.T, xci[2]) # physical cell centers
 ```
 
 and we define a rectangular thermal anomaly at $x \in [0, 0.05]$, $y \in [\frac{1}{3} - 0.05, \frac{1}{3} + 0.05]$
 ```julia
-function rectangular_perturbation!(T, xc, yc, r, xvi)
+function rectangular_perturbation!(T, xc, yc, r, xci)
     @parallel_indices (i, j) function _rectangular_perturbation!(T, xc, yc, r, x, y)
         if ((x[i]-xc)^2 ≤ r^2) && ((y[j] - yc)^2 ≤ r^2)
-            T[i+1, j] += .2
+            T[i+1, j+1] += .2
         end
         return nothing
     end
-    nx, ny = size(T)
-    @parallel (1:nx-2, 1:ny) _rectangular_perturbation!(T, xc, yc, r, xvi...)
+    ni = size(T) .- 2
+    @parallel (@idx ni) _rectangular_perturbation!(T, xc, yc, r, xci...)
     return nothing
 end
 
 xc_anomaly  = 0.0    # center of the thermal anomaly
 yc_anomaly  = 1/3    # center of the thermal anomaly
 r_anomaly   = 0.1/2  # half-width of the thermal anomaly
-rectangular_perturbation!(thermal.T, xc_anomaly, yc_anomaly, r_anomaly, xvi)
+rectangular_perturbation!(thermal.T, xc_anomaly, yc_anomaly, r_anomaly, xci)
 ```
 
 We initialize the buoyancy forces and viscosity
@@ -173,7 +175,7 @@ We initialize the buoyancy forces and viscosity
 η                = @ones(ni...)
 args             = (; T = thermal.T, P = stokes.P, dt = Inf)
 compute_ρg!(ρg[2], phase_ratios, rheology, args)
-compute_viscosity!(stokes, 1.0, phase_ratios, args, rheology, (-Inf, Inf))
+compute_viscosity!(stokes, phase_ratios, args, rheology, (-Inf, Inf))
 ```
 where `(-Inf, Inf)` is the viscosity cutoff.
 
@@ -198,28 +200,13 @@ pt_thermal  = PTThermalCoeffs(
 ```
 
 ### Just before solving the problem...
-We need to allocate some arrays to be able to do the subgrid diffusion of the temperature field at the particles level:
+We need a ghost-free buffer of the cell-centered temperature; it is the array exchanged with the particles, since [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl) does not handle ghost nodes.
 ```julia
-T_buffer    = @zeros(ni.+1)     # without the ghost nodes at the x-direction
-Told_buffer = similar(T_buffer) # without the ghost nodes at the x-direction
-dt₀         = similar(stokes.P) # subgrid diffusion time scale
-# copy temperature to buffer arrays
-for (dst, src) in zip((T_buffer, Told_buffer), (thermal.T, thermal.Told))
-    copyinn_x!(dst, src)
-end
-# interpolate temperatyre on the particles
-grid2particle!(pT, T_buffer, particles)
-pT0.data    .= pT.data
-```
-where
-```julia
-function copyinn_x!(A, B)
-    @parallel function f_x(A, B)
-        @all(A) = @inn_x(B)
-        return nothing
-    end
-    @parallel f_x(A, B)
-end
+T_buffer = thermal.T[2:end-1, 2:end-1] # without the ghost nodes
+dt₀      = similar(stokes.P)           # subgrid diffusion time scale
+# interpolate temperature onto the particles
+centroid2particle!(pT, T_buffer, particles)
+pT0.data .= pT.data
 ```
 
 In this benchmark we want to keep track of the time `trms`, the rms-velocity `Urms`
@@ -251,7 +238,7 @@ Vy_v = @zeros(ni.+1...)
 solve!(
     stokes,
     pt_stokes,
-    di,
+    grid,
     flow_bcs,
     ρg,
     phase_ratios,
@@ -278,7 +265,7 @@ heatdiffusion_PT!(
     rheology,
     args,
     dt,
-    di;
+    grid;
     kwargs = (;
         igg     = igg,
         phase   = phase_ratios,
@@ -290,15 +277,13 @@ heatdiffusion_PT!(
 ```
 3. Subgrid diffusion at the particle level
 ```julia
-for (dst, src) in zip((T_buffer, Told_buffer), (thermal.T, thermal.Told))
-    copyinn_x!(dst, src)
-end
+@views T_buffer .= thermal.T[2:end-1, 2:end-1]
 subgrid_characteristic_time!(
     subgrid_arrays, particles, dt₀, phase_ratios, rheology, thermal, stokes
 )
 centroid2particle!(subgrid_arrays.dt₀, dt₀, particles)
-subgrid_diffusion!(
-    pT, T_buffer, thermal.ΔT[2:end-1, :], subgrid_arrays, particles, dt
+subgrid_diffusion_centroid!(
+    pT, T_buffer, thermal.ΔT, subgrid_arrays, particles, dt
 )
 ```
 4. Advect particles
@@ -314,23 +299,24 @@ update_phase_ratios!(phase_ratios, particles, pPhases)
 ```
 5.  Interpolate `T` back to the grid
 ```julia
-# interpolate fields from particle to grid vertices
-particle2grid!(T_buffer, pT, particles)
-@views T_buffer[:, end]      .= 0.0
-@views T_buffer[:, 1]        .= 1.0
-@views thermal.T[2:end-1, :] .= T_buffer
+# interpolate fields from the particles to the cell centers
+particle2centroid!(T_buffer, pT, particles)
+@views T_buffer[:, end] .= 0.0
+@views T_buffer[:, 1]   .= 1.0
+@views thermal.T[2:end-1, 2:end-1] .= T_buffer
+thermal_bcs!(thermal, thermal_bc)
 flow_bcs!(stokes, flow_bcs) # apply boundary conditions
 ```
 6. Update buoyancy forces and viscosity
 ```julia
 args = (; T = thermal.T, P = stokes.P,  dt=Inf)
-compute_viscosity!(stokes, 1.0, phase_ratios, args, rheology, (-Inf, Inf))
+compute_viscosity!(stokes, phase_ratios, args, rheology, (-Inf, Inf))
 compute_ρg!(ρg[2], phase_ratios, rheology, args)
 ```
 7. Compute Nusselt number and rms-velocity
 ```julia
 # Nusselt number, Nu = ∫ ∂T/∂z dx
-Nu_it = sum( ((abs.(thermal.T[2:end-1,end] - thermal.T[2:end-1,end-1])) ./ di[2]) .*di[1])
+Nu_it = sum( ((abs.(thermal.T[2:end-1,end] - thermal.T[2:end-1,end-1])) ./ di[2]) .* di[1])
 push!(Nu_top, Nu_it)
 # Compute U rms
 # U₍ᵣₘₛ₎ = √ ∫∫ (vx²+vz²) dx dz
@@ -366,7 +352,7 @@ ax2 = Axis(fig[2,1], aspect = ar, title = "Vy [m/s]")
 ax3 = Axis(fig[1,3], aspect = ar, title = "Vx [m/s]")
 ax4 = Axis(fig[2,3], aspect = ar, title = "T [K]")
 # grid temperature
-h1  = heatmap!(ax1, xvi[1], xvi[2], Array(thermal.T[2:end-1,:]) , colormap=:lajolla, colorrange=(0, 1) )
+h1  = heatmap!(ax1, xci[1], xci[2], Array(T_buffer) , colormap=:lajolla, colorrange=(0, 1) )
 # y-velocity
 h2  = heatmap!(ax2, xvi[1], xvi[2], Array(stokes.V.Vy) , colormap=:batlow)
 # x-velocity
@@ -381,7 +367,6 @@ Colorbar(fig[2,2], h2)
 Colorbar(fig[1,4], h3)
 Colorbar(fig[2,4], h4)
 linkaxes!(ax1, ax2, ax3, ax4)
-save(joinpath(figdir, "$(it).png"), fig)
 fig
 ```
 

--- a/docs/src/man/ShearBands.md
+++ b/docs/src/man/ShearBands.md
@@ -15,12 +15,6 @@ import JustPIC._2D.GridGeometryUtils as GGU
 const backend_JP = JustPIC.CPUBackend
 ```
 
-```julia
-using JustPIC, JustPIC._2D
-import JustPIC._2D.GridGeometryUtils as GGU
-const backend_JP = JustPIC.CPUBackend
-```
-
 We will also use [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) to write some device-agnostic helper functions:
 ```julia
 using ParallelStencil
@@ -87,6 +81,7 @@ rheology = (
     ),
     # High density phase
     SetMaterialParams(;
+        Phase             = 2,
         Density           = ConstantDensity(; ρ = 0.0),
         Gravity           = ConstantGravity(; g = 0.0),
         CompositeRheology = CompositeRheology((visc, el_inc, pl)),
@@ -149,7 +144,7 @@ pt_stokes = PTStokesCoeffs(li, di; ϵ_abs = 1.0e-6, ϵ_rel = 1.0e-6, CFL = 0.95 
 We initialize the buoyancy forces and viscosity
 ```julia
 ρg               = @zeros(ni...), @zeros(ni...)
-args             = (; T = @zeros(ni...), P = stokes.P, dt = Inf)
+args             = (; T = @zeros(ni .+ 2...), P = stokes.P, dt = dt)
 viscosity_cutoff = (-Inf, Inf)
 compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
 ```
@@ -190,7 +185,7 @@ for it in 1:nt
     solve!(
         stokes,
         pt_stokes,
-        di,
+        grid,
         flow_bcs,
         ρg,
         phase_ratios,
@@ -207,10 +202,10 @@ for it in 1:nt
         )
     )
     # advance time step
-    it += 1
-    t  += dt
-    # calculate the second invariant and push to history vectors
+    t += dt
+    # calculate the second invariants and push to history vectors
     tensor_invariant!(stokes.ε)
+    tensor_invariant!(stokes.ε_pl)
     push!(τII, maximum(stokes.τ.xx))
     push!(sol, solution(εbg, t, G0, η0))
     push!(ttot, t)
@@ -247,7 +242,6 @@ lines!(ax4, ttot, sol, color = :red)
 hidexdecorations!(ax1)
 hidexdecorations!(ax3)
 fig
-save(joinpath(figdir, "$(it).png"), fig)
 ```
 
 ### Final model

--- a/docs/src/man/grid_generation.md
+++ b/docs/src/man/grid_generation.md
@@ -41,7 +41,7 @@ using JustRelax
 xv = [0.0, 0.1, 0.2, 0.4, 0.7, 1.0]
 yv = [-1.0, -0.7, -0.45, -0.2, 0.0]
 
-grid = Geometry(xv, yv)
+grid = Geometry((xv, yv))
 
 xci = grid.xci
 xvi = grid.xvi
@@ -57,7 +57,7 @@ This constructor derives:
 - nonuniform spacings with `diff.(xvi)`
 - staggered velocity grids with the required ghost points
 
-If you want the coordinate arrays stored in a specific array type, pass an array constructor as the first argument:
+The vertex coordinates are passed as a tuple. If you want the coordinate arrays stored in a specific array type, pass an array constructor as the first argument, in which case the coordinates are given as separate arguments:
 
 ```julia
 grid = Geometry(Array, xv, yv)

--- a/docs/src/man/plume3D/plume3D.md
+++ b/docs/src/man/plume3D/plume3D.md
@@ -1,70 +1,96 @@
-# 3D Plume 
+# 3D Plume
 
+A thermal plume rising through a layered lithosphere. The complete, runnable script is at [`miniapps/convection/Plume3D/Plume3D.jl`](https://github.com/PTsolvers/JustRelax.jl/blob/main/miniapps/convection/Plume3D/Plume3D.jl); the sections below walk through it.
 
 # Initialize packages
 
-Load JustRelax necessary modules and define backend. In this case we will use the CUDA backend, but you can also use the CPU or AMD GPU backends.
+Load JustRelax and define the backend. Set `isCUDA = true` to run on a CUDA GPU, or load AMDGPU.jl and use `AMDGPUBackend` for an AMD GPU.
 ```julia
-using CUDA # comment this out if you are not using CUDA; or load AMDGPU.jl if you are using an AMD GPU
+const isCUDA = false
+
+@static if isCUDA
+    using CUDA
+end
+
 using JustRelax, JustRelax.JustRelax3D, JustRelax.DataIO
 using Pkg; Pkg.activate("miniapps")
-const backend_JR = CUDABackend  # Options: CPUBackend, CUDABackend, AMDGPUBackend
-```
 
-For this benchmark we will use particles to track the advection of the material phases and their information. For this, we will use [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl)
-```julia
-using JustPIC, JustPIC._3D
-const backend = CUDABackend # Options: JustPIC.CPUBackend, CUDABackend, JustPIC.AMDGPUBackend
+const backend_JR = @static if isCUDA
+    CUDABackend  # Options: CPUBackend, CUDABackend, AMDGPUBackend
+else
+    JustRelax.CPUBackend
+end
 ```
 
 We will also use [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) to write some device-agnostic helper functions:
 ```julia
-using ParallelStencil
-@init_parallel_stencil(CUDA, Float64, 3)
+using ParallelStencil, ParallelStencil.FiniteDifferences3D
+
+@static if isCUDA
+    @init_parallel_stencil(CUDA, Float64, 3)
+else
+    @init_parallel_stencil(Threads, Float64, 3)
+end
+```
+
+Particles track the advection of the material phases and their information. For this we use [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl), which needs its own backend:
+```julia
+using JustPIC, JustPIC._3D
+
+const backend_JP = @static if isCUDA
+    CUDABackend  # Options: JustPIC.CPUBackend, CUDABackend, JustPIC.AMDGPUBackend
+else
+    JustPIC.CPUBackend
+end
+
+using GeoParams, CairoMakie, Printf
 ```
 
 # Model setup
 
-
 ## Model domain
 ```julia
-lz            = 700.0e3       # domain length in z
-lx            = ly = lz       # domain length in x and y
-ni            = nx, ny, nz    # number of cells
-li            = lx, ly, lz    # domain length
-di            = @. li / ni    # grid steps
-origin        = 0.0, 0.0, -lz # origin coordinates (15km of sticky air layer)
-grid          = Geometry(ni, li; origin = origin)
-(; xci, xvi)  = grid          # nodes at the center and vertices of the cells
+nx = ny = nz = 32             # number of cells per direction
+lz           = 700.0e3        # domain length in z
+lx           = ly = lz        # domain length in x and y
+ni           = nx, ny, nz     # number of cells
+li           = lx, ly, lz     # domain length
+di           = @. li / ni     # grid steps
+origin       = 0.0, 0.0, -lz  # origin coordinates
+grid         = Geometry(ni, li; origin = origin)
+(; xci, xvi) = grid           # nodes at the center and vertices of the cells
 ```
 
 ## Physical properties using GeoParams
-For the rheology we will use the `rheology` object we created in the previous section.
+For the rheology we will use the `rheology` object we created in the previous section. Its thermal properties also set the diffusive limit on the time step:
+```julia
+κ  = 10 / (rheology[1].HeatCapacity[1].Cp * rheology[1].Density[1].ρ0)
+dt = dt_diff = 0.5 * min(di...)^3 / κ / 3.01 # diffusive CFL timestep limiter
+```
 
 ## Initialize particles fields
 ```julia
-nxcell         = 25
-max_xcell      = 35
-min_xcell      = 8
-particles      = init_particles(backend, nxcell, max_xcell, min_xcell, grid.xi_vel...)
-subgrid_arrays = SubgridDiffusionCellArrays(particles)
+nxcell, max_xcell, min_xcell = 25, 35, 8
+particles      = init_particles(backend_JP, nxcell, max_xcell, min_xcell, grid.xi_vel...)
+subgrid_arrays = SubgridDiffusionCellArrays(particles; loc = :center)
 ```
+
+`loc = :center` because the resolved temperature field of `ThermalArrays` lives at the cell centers.
 
 We would like to advect two fields stored at the particles, the temperature `pT`, and the material phases of each particle `pPhases`, which we initialize as `CellArray` objects:
 ```julia
-pPhases, pT      = init_cell_arrays(particles, Val(2))
-particle_args    = (pT, pPhases)
+pT, pPhases   = init_cell_arrays(particles, Val(2))
+particle_args = (pT, pPhases)
 ```
 
 ## Assign particles phases
+The lithosphere is layered by depth, and a cubic plume of half-width `r` is placed at depth `d`:
 ```julia
-
 function init_phases!(phases, particles, Lx, Ly; d = 650.0e3, r = 50.0e3)
     ni = size(phases)
 
-    @parallel_indices (I...) function init_phases!(phases, px, py, pz, index, r, Lx, Ly)
-
-        @inbounds for ip in cellaxes(phases)
+    @parallel_indices (I...) function _init_phases!(phases, px, py, pz, index, r, d, Lx, Ly)
+        for ip in cellaxes(phases)
             # quick escape
             @index(index[ip, I...]) == 0 && continue
 
@@ -94,7 +120,7 @@ function init_phases!(phases, particles, Lx, Ly; d = 650.0e3, r = 50.0e3)
         return nothing
     end
 
-    return @parallel (@idx ni) init_phases!(phases, particles.coords..., particles.index, r, Lx, Ly)
+    return @parallel (@idx ni) _init_phases!(phases, particles.coords..., particles.index, r, d, Lx, Ly)
 end
 ```
 
@@ -104,40 +130,41 @@ yc_anomaly = ly / 2   # origin of thermal anomaly
 zc_anomaly = -610.0e3 # origin of thermal anomaly
 r_anomaly  = 50.0e3   # radius of perturbation
 init_phases!(pPhases, particles, lx, ly; d = abs(zc_anomaly), r = r_anomaly)
-phase_ratios = PhaseRatios(backend, length(rheology), ni)
+phase_ratios = PhaseRatios(backend_JP, length(rheology), ni)
 update_phase_ratios!(phase_ratios, particles, pPhases)
 ```
 
-## Define temperature profile
+## Instantiate Stokes arrays
+Instantiate the Stokes object with the `PTStokesCoeffs` defining the necessary pseudo transient variables including the relative $\epsilon_{rel}$ and the absolute tolerance $\epsilon_{abs}$
+
 ```julia
-thermal     = ThermalArrays(backend, ni)
-thermal_bc  = TemperatureBoundaryConditions(;
-    no_flux = (left = true, right = true, top = false, bot = false, front = true, back = true),
-)
-thermal_bcs!(thermal, thermal_bc)
+stokes    = StokesArrays(backend_JR, ni)
+pt_stokes = PTStokesCoeffs(li, di; ϵ_abs = 1.0e-4, ϵ_rel = 1.0e-4, Re = 3π, r = 1.0e0, CFL = 0.9 / √3.1)
 ```
 
+## Define temperature profile
+The geotherm is piecewise linear in depth:
 ```julia
 @parallel_indices (I...) function init_T!(T, z)
-    depth = -z[I[end]]
+    depth = -z[I[3]]
 
-    if depth < 0.0
+    if depth < 0.0e0
         T[I...] = 273.0
 
-    elseif 0.0 ≤ (depth) < 35e3
-        dTdZ = (923 - 273) / 35e3
-        offset = 273
-        T[I...] = (depth) * dTdZ + offset
+    elseif 0.0e0 ≤ depth < 35.0e3
+        dTdZ = (923 - 273) / 35.0e3
+        offset = 273.0e0
+        T[I...] = depth * dTdZ + offset
 
-    elseif 110e3 > (depth) ≥ 35e3
-        dTdZ = (1492 - 923) / 75e3
-        offset = 923
-        T[I...] = (depth - 35e3) * dTdZ + offset
+    elseif 110.0e3 > depth ≥ 35.0e3
+        dTdZ = (1492 - 923) / 75.0e3
+        offset = 923.0e0
+        T[I...] = (depth - 35.0e3) * dTdZ + offset
 
-    elseif (depth) ≥ 110e3
-        dTdZ = (1837 - 1492) / 590e3
-        offset = 1492
-        T[I...] = (depth - 110e3) * dTdZ + offset
+    elseif depth ≥ 110.0e3
+        dTdZ = (1837 - 1492) / 590.0e3
+        offset = 1492.0e0
+        T[I...] = (depth - 110.0e3) * dTdZ + offset
 
     end
 
@@ -145,12 +172,13 @@ thermal_bcs!(thermal, thermal_bc)
 end
 ```
 
+on top of which we superimpose a hotter rectangular anomaly co-located with the plume:
 ```julia
 # Thermal rectangular perturbation
 function rectangular_perturbation!(T, xc, yc, zc, r, xvi)
 
     @parallel_indices (i, j, k) function _rectangular_perturbation!(T, xc, yc, zc, r, x, y, z)
-        @inbounds if (abs(x[i] - xc) ≤ r) && (abs(y[j] - yc) ≤ r) && (abs(z[k] - zc) ≤ r)
+        if (abs(x[i] - xc) ≤ r) && (abs(y[j] - yc) ≤ r) && (abs(z[k] - zc) ≤ r)
             depth = abs(z[k])
             dTdZ = (2047 - 2017) / 50.0e3
             offset = 2017
@@ -163,38 +191,43 @@ function rectangular_perturbation!(T, xc, yc, zc, r, xvi)
 end
 ```
 
+`thermal.T` is a cell-centered field surrounded by one ring of ghost nodes, so the profile is built on the vertices and then transferred to the centers with `vertex2center!`:
 ```julia
 thermal    = ThermalArrays(backend_JR, ni)
-
-# initialize thermal profile - Half space cooling
-@parallel init_T!(thermal.T, xvi[3])
-rectangular_perturbation!(thermal.T, xc_anomaly, yc_anomaly, zc_anomaly, r_anomaly, xvi)
-```
-
-```julia
 thermal_bc = TemperatureBoundaryConditions(;
     no_flux = (left = true, right = true, top = false, bot = false, front = true, back = true),
 )
+
+T_vertex = @zeros(ni .+ 1...)
+@parallel (@idx ni .+ 1) init_T!(T_vertex, xvi[3])
+rectangular_perturbation!(T_vertex, xc_anomaly, yc_anomaly, zc_anomaly, r_anomaly, xvi)
+vertex2center!(thermal.T, T_vertex; ghost_x = true, ghost_y = true, ghost_z = true)
 thermal_bcs!(thermal, thermal_bc)
-```
-
-## Instantiate Stokes arrays
-Instantiate the Stokes object with the `PTStokesCoeffs` defining the necessary pseudo transient variables including the relative  $\epsilon_{rel}$ and the absolute tolerance $\epsilon_{abs}$  
-
-```julia
-stokes    = StokesArrays(backend, ni)
-pt_stokes = PTStokesCoeffs(li, di; ϵ_rel=1e-4, Re=3π, r=1e0, CFL = 0.98 / √3)
 ```
 
 ## Initialize buoyancy forces and lithostatic pressure
 ```julia
-ρg        = ntuple(_ -> @zeros(ni...), Val(3))
+ρg = ntuple(_ -> @zeros(ni...), Val(3))
 compute_ρg!(ρg[end], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
-stokes.P .= PTArray(backend)(reverse(cumsum(reverse((ρg[end]).* di[end], dims=3), dims=3), dims=3))
+stokes.P .= PTArray(backend_JR)(reverse(cumsum(reverse(ρg[end] .* di[end], dims = 3), dims = 3), dims = 3))
+```
+
+## Initialize viscosity
+```julia
+args             = (; T = thermal.T, P = stokes.P, dt = Inf)
+viscosity_cutoff = (1.0e18, 1.0e24)
+compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
+```
+
+## Pseudo-transient coefficients
+```julia
+pt_thermal = PTThermalCoeffs(
+    backend_JR, rheology, phase_ratios, args, dt, ni, di, li; ϵ = 1.0e-5, CFL = 0.95 / √3
+)
 ```
 
 ## Define boundary conditions
-We we will use free slip boundary conditions on all sides
+We will use free slip boundary conditions on all sides
 ```julia
 # Boundary conditions
 flow_bcs = VelocityBoundaryConditions(;
@@ -202,19 +235,15 @@ flow_bcs = VelocityBoundaryConditions(;
     no_slip = (left = false, right = false, top = false, bot = false, front = false, back = false),
 )
 flow_bcs!(stokes, flow_bcs) # apply boundary conditions
-```
-
-## Pseuo-transient coefficients
-```julia
-pt_thermal = PTThermalCoeffs(
-    backend, rheology, phase_ratios, args0, dt, ni, di, li; ϵ=1e-5, CFL=0.98 / √3
-)
+update_halo!(@velocity(stokes)...)
 ```
 
 ## Just before solving the problem...
+`T_buffer` is the ghost-free view of the centroid temperature; it is the array exchanged with the particles.
 ```julia
-dt₀         = similar(stokes.P)
-grid2particle!(pT, T_buffer, particles)
+T_buffer = thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)]
+centroid2particle!(pT, T_buffer, particles)
+dt₀      = similar(stokes.P)
 ```
 
 # Solving the problem
@@ -222,17 +251,19 @@ We will now advance the model in time, solving the Stokes and thermal equations,
 
 ## Advancing one time step
 
-1. Interpolate fields from particle to grid vertices
+1. Interpolate the temperature from the particles back to the cell centers
 ```julia
-particle2grid!(T_buffer, pT, particles)
+particle2centroid!(T_buffer, pT, particles)
+@views thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)] .= T_buffer
+thermal_bcs!(thermal, thermal_bc)
 ```
 2. Solve stokes
 ```julia
- t_stokes = @elapsed begin
+t_stokes = @elapsed begin
     out = solve!(
         stokes,
         pt_stokes,
-        di,
+        grid,
         flow_bcs,
         ρg,
         phase_ratios,
@@ -243,17 +274,18 @@ particle2grid!(T_buffer, pT, particles)
         kwargs = (;
             iterMax = 100.0e3,
             nout = 1.0e3,
-            viscosity_cutoff = (1e18, 1e24),
+            viscosity_cutoff = viscosity_cutoff,
         )
-    );
+    )
 end
 println("Stokes solver time             ")
 println("   Total time:      $t_stokes s")
 println("   Time/iteration:  $(t_stokes / out.iter) s")
+tensor_invariant!(stokes.ε)
 ```
 3. Update time step
 ```julia
-dt = compute_dt(stokes, di) * 0.8
+dt = compute_dt(stokes, di, dt_diff) * 0.8
 ```
 
 4. Thermal solver and subgrid diffusion
@@ -265,12 +297,12 @@ heatdiffusion_PT!(
     rheology,
     args,
     dt,
-    di;
-    kwargs = (
+    grid;
+    kwargs = (;
         igg     = igg,
         phase   = phase_ratios,
-        iterMax = 50e3,
-        nout    = 1e2,
+        iterMax = 50.0e3,
+        nout    = 1.0e2,
         verbose = true,
     )
 )
@@ -279,36 +311,39 @@ subgrid_characteristic_time!(
     subgrid_arrays, particles, dt₀, phase_ratios, rheology, thermal, stokes
 )
 centroid2particle!(subgrid_arrays.dt₀, dt₀, particles)
-subgrid_diffusion!(
-    pT, thermal.T, thermal.ΔT, subgrid_arrays, particles, dt
+subgrid_diffusion_centroid!(
+    pT, T_buffer, thermal.ΔT, subgrid_arrays, particles, dt
 )
 ```
 
 5. Particles advection
 ```julia
 # advect particles in space
-advection!(particles, RungeKutta2(), @velocity(stokes), dt)
+advection_MQS!(particles, RungeKutta2(), @velocity(stokes), dt)
 # advect particles in memory
 move_particles!(particles, particle_args)
 # check if we need to inject particles
-inject_particles_phase!(particles, pPhases, (pT, ), (thermal.T, ))
+inject_particles_phase!(particles, pPhases, (pT,), (T_buffer,))
 # update phase ratios
 update_phase_ratios!(phase_ratios, particles, pPhases)
 ```
 
 6. **Optional:** Save data as VTK to visualize it later with [ParaView](https://www.paraview.org/)
 ```julia
-Vx_v = @zeros(ni.+1...)
-Vy_v = @zeros(ni.+1...)
-Vz_v = @zeros(ni.+1...)
+Vx_v = @zeros(ni .+ 1...)
+Vy_v = @zeros(ni .+ 1...)
+Vz_v = @zeros(ni .+ 1...)
 velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
 data_v = (;
-    T = Array(thermal.T),
+    T = Array(T_vertex),
 )
 data_c = (;
-    T = Array(thermal.T[2:end-1, 2:end-1, 2:end-1]),
+    T = Array(T_buffer),
     P = Array(stokes.P),
+    τII = Array(stokes.τ.II),
+    εII = Array(stokes.ε.II),
     η = Array(log10.(stokes.viscosity.η_vep)),
+    phase = [argmax(p) for p in Array(phase_ratios.center)],
 )
 velocity_v = (
     Array(Vx_v),

--- a/docs/src/man/plume3D/rheology.md
+++ b/docs/src/man/plume3D/rheology.md
@@ -1,6 +1,6 @@
 # Using GeoParams.jl to define the rheology of the material phases
 
-In this example, we will define a rheology for a 3D plume model using the `GeoParams.jl` package. The model will consist of for four different rheology layers: upper crust, lower crust, lithospheric mantle, and sublithospheric mantle. We will use a non-Newtoninan visco-elasto-plastic rheology.
+In this example, we will define a rheology for a 3D plume model using the `GeoParams.jl` package. The model consists of five material phases: upper crust, lower crust, lithospheric mantle, sublithospheric mantle, and the plume itself. We will use a non-Newtonian visco-elasto-plastic rheology.
 
 We will start by defining the physical parameters of the diffusion and dislocation creep laws of every phase:
 
@@ -26,17 +26,15 @@ el_sublithospheric_mantle = SetConstantElasticity(; G = 67.0e9, ν = 0.5)
 β_sublithospheric_mantle  = inv(get_Kb(el_sublithospheric_mantle))
 ```
 
-plastic properties, where we use the regularised Drucker-Prager model:
+plastic properties, where we use the regularized Drucker-Prager model:
 ```julia
 η_reg    = 1.0e16
 cohesion = 3.0e6
-friction = asind(0.2)
-pl_crust = DruckerPrager_regularised(; C = cohesion, ϕ = friction, η_vp = η_reg, Ψ = 0.0) 
-friction = asind(0.3)
-pl       = DruckerPrager_regularised(; C = cohesion, ϕ = friction, η_vp = η_reg, Ψ = 0.0) # 
+pl_crust = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.2), η_vp = η_reg, Ψ = 0.0)
+pl       = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.3), η_vp = η_reg, Ψ = 0.0)
 ```
 
-then the pressure- and temperature-dependant thermal conductivities for the crust and mantle:
+then the pressure- and temperature-dependent thermal conductivities for the crust and mantle:
 ```julia
 K_crust = TP_Conductivity(;
     a = 0.64,
@@ -52,7 +50,7 @@ K_mantle = TP_Conductivity(;
 )
 ```
 
-and finally we can things up together in a `rheology` tuple along with other material properties:
+and finally we can put things together in a `rheology` tuple along with the other material properties. The plume shares its creep, elastic and thermal properties with the sublithospheric mantle, and differs only in its reference density `ρ0`, which is 50 kg/m³ lighter; this density contrast is what drives the upwelling:
 ```julia
 rheology = (
     # Name              = "UpperCrust",
@@ -83,9 +81,18 @@ rheology = (
         CompositeRheology= CompositeRheology((disl_lithospheric_mantle, diff_lithospheric_mantle, el_lithospheric_mantle, pl)),
         Elasticity       = el_lithospheric_mantle,
     ),
-    # Name              = "Plume",
+    # Name              = "SubLithosphericMantle",
     SetMaterialParams(;
         Phase            = 4,
+        Density          = PT_Density(; ρ0 = 3.3e3, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+        HeatCapacity     = ConstantHeatCapacity(; Cp = 1.25e3),
+        Conductivity     = K_mantle,
+        CompositeRheology= CompositeRheology((disl_sublithospheric_mantle, diff_sublithospheric_mantle, el_sublithospheric_mantle)),
+        Elasticity       = el_sublithospheric_mantle,
+    ),
+    # Name              = "Plume",
+    SetMaterialParams(;
+        Phase            = 5,
         Density          = PT_Density(; ρ0 = 3.3e3 - 50, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
         HeatCapacity     = ConstantHeatCapacity(; Cp = 1.25e3),
         Conductivity     = K_mantle,

--- a/docs/src/man/restart.md
+++ b/docs/src/man/restart.md
@@ -30,7 +30,7 @@ particles     = TA(backend)(Float64, data["particles"])
 phases        = TA(backend)(Float64, data["phases"])
 phase_ratios  = TA(backend)(Float64, data["phase_ratios"])
 particle_args = TA(backend).(Float64, data["particle_args"])
-subgrid_arrays  = SubgridDiffusionCellArrays(particles)
+subgrid_arrays  = SubgridDiffusionCellArrays(particles; loc = :center)
 ```
 
 ## Load Stokes and Thermal arrays from checkpoint file

--- a/docs/src/man/subduction2D/rheology.md
+++ b/docs/src/man/subduction2D/rheology.md
@@ -26,10 +26,10 @@ diff_wet_olivine  = SetDiffusionCreep(Diffusion.wet_olivine_Hirth_2003)
 
 and where plastic failure is given by the formulation from [Duretz et al, 2021](https://doi.org/10.1029/2021GC009675)
 ```julia
-# non-regularized plasticity
 ϕ               = asind(0.1)
 C               = 1e6        # Pa
-plastic_model   = DruckerPrager_regularised(; C = C, ϕ = ϕ, η_vp=η_reg, Ψ=0.0)
+η_reg           = 1e20       # Pa s, viscosity of the regularisation dashpot
+plastic_model   = DruckerPrager_regularised(; C = C, ϕ = ϕ, η_vp = η_reg, Ψ = 0.0)
 ```
 
 Finally we define the rheology objects of [GeoParams.jl](https://github.com/JuliaGeodynamics/GeoParams.jl)

--- a/docs/src/man/subduction2D/setup.md
+++ b/docs/src/man/subduction2D/setup.md
@@ -3,8 +3,10 @@ As described in the original [paper](https://doi.org/10.5194/se-15-567-2024), th
 
 We will use [GeophysicalModelGenerator.jl](https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl) to generate the initial geometry, material phases, and thermal field of our models. We will start by defining the dimensions and resolution of our model, as well as initializing the `Grid2D` object and two arrays `Phases` and `Temp` that host the material phase (given by an integer) and the thermal field, respectively.
 
+The `Grid2D` object holds the field values at the *vertices* of the computational grid, so it needs one more point per direction than the number of cells of the model.
+
 ```julia
-nx, nz        = 512, 218 # number of cells per dimension
+nx, nz        = 257, 129 # number of grid vertices per dimension
 Tbot          = 1474.0   # [Celsius]
 model_depth   = 660      # [km]
 air_thickness = 10       # [km]

--- a/docs/src/man/subduction2D/subduction2D.md
+++ b/docs/src/man/subduction2D/subduction2D.md
@@ -6,35 +6,47 @@ Model setups taken from [Hummel et al 2024](https://doi.org/10.5194/se-15-567-20
 
 Load JustRelax necessary modules and define backend.
 ```julia
-using CUDA # comment this out if you are not using CUDA; or load AMDGPU.jl if you are using an AMD GPU
+const isCUDA = false
+
+@static if isCUDA
+    using CUDA
+end
+
 using JustRelax, JustRelax.JustRelax2D, JustRelax.DataIO
 using Pkg; Pkg.activate("miniapps")
-const backend_JR = CUDABackend  # Options: CPUBackend, CUDABackend, AMDGPUBackend
+
+const backend_JR = @static if isCUDA
+    CUDABackend  # Options: CPUBackend, CUDABackend, AMDGPUBackend
+else
+    JustRelax.CPUBackend
+end
 ```
 
 For this benchmark we will use particles to track the advection of the material phases and their information. For this, we will use [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl)
 ```julia
 using JustPIC, JustPIC._2D
-const backend = CUDABackend # Options: JustPIC.CPUBackend, CUDABackend, JustPIC.AMDGPUBackend
+
+const backend_JP = @static if isCUDA
+    CUDABackend # Options: JustPIC.CPUBackend, CUDABackend, JustPIC.AMDGPUBackend
+else
+    JustPIC.CPUBackend
+end
 ```
 
 We will also use [ParallelStencil.jl](https://github.com/omlins/ParallelStencil.jl) to write some device-agnostic helper functions:
 ```julia
-using ParallelStencil
-@init_parallel_stencil(CUDA, Float64, 2)
-```
-### Helper function
-We first define a helper function that will be useful later on
+using ParallelStencil, ParallelStencil.FiniteDifferences2D
 
-```julia
-function copyinn_x!(A, B)
-    @parallel function f_x(A, B)
-        @all(A) = @inn_x(B)
-        return nothing
-    end
-
-    @parallel f_x(A, B)
+@static if isCUDA
+    @init_parallel_stencil(CUDA, Float64, 2)
+else
+    @init_parallel_stencil(Threads, Float64, 2)
 end
+```
+
+and finally the packages used to define the material properties and to plot the results:
+```julia
+using GeoParams, CairoMakie
 ```
 
 # Model setup
@@ -42,8 +54,9 @@ We will use [GeophysicalModelGenerator.jl](https://github.com/JuliaGeodynamics/G
 
 
 ## Model domain
+`li` and `origin` are the domain length and lower-left corner returned by the setup routine of the previous section, and `phases_GMG` and `T_GMG` are the corresponding phase and temperature fields.
 ```julia
-nx, ny        = 256, 128         # number of cells in x and y directions
+nx, ny        = 256, 128         # number of cells in x and y directions (one less than the GMG grid)
 ni            = nx, ny
 di            = @. li / ni       # grid steps
 grid          = Geometry(ni, li; origin = origin)
@@ -51,16 +64,22 @@ grid          = Geometry(ni, li; origin = origin)
 ```
 
 ## Physical properties using GeoParams
-For the rheology we will use the `rheology` object we created in the previous section.
+For the rheology we will use the `rheology` object we created in the previous section. We also set an initial time step and the bounds within which the effective viscosity is clamped:
+```julia
+dt               = 10.0e3 * 3600 * 24 * 365 # 10 kyr
+viscosity_cutoff = (1.0e18, 1.0e23)
+```
 
 ## Initialize particles fields
 ```julia
 nxcell          = 40 # initial number of particles per cell
 max_xcell       = 60 # maximum number of particles per cell
 min_xcell       = 20 # minimum number of particles per cell
-particles       = init_particles(backend, nxcell, max_xcell, min_xcell, grid.xi_vel...)
-subgrid_arrays  = SubgridDiffusionCellArrays(particles)
+particles       = init_particles(backend_JP, nxcell, max_xcell, min_xcell, grid.xi_vel...)
+subgrid_arrays  = SubgridDiffusionCellArrays(particles; loc = :center)
 ```
+
+`loc = :center` because the resolved temperature field of `ThermalArrays` lives at the cell centers.
 
 We would like to advect two fields stored at the particles, the temperature `pT`, and the material phases of each particle `pPhases`, which we initialize as `CellArray` objects:
 ```julia
@@ -69,10 +88,49 @@ particle_args    = (pT, pPhases)
 ```
 
 ## Assign particles phases
+`phases_GMG` is defined on the grid vertices, so each particle takes the phase of the nearest vertex of its cell:
+```julia
+function init_phases!(phases, phase_grid, particles, xvi)
+    ni = size(phases)
+    @parallel (@idx ni) _init_phases!(phases, phase_grid, particles.coords, particles.index, xvi)
+end
+
+@parallel_indices (I...) function _init_phases!(phases, phase_grid, pcoords::NTuple{N, T}, index, xvi) where {N, T}
+    ni = size(phases)
+
+    for ip in cellaxes(phases)
+        # quick escape
+        @index(index[ip, I...]) == 0 && continue
+
+        pᵢ = ntuple(Val(N)) do i
+            @index pcoords[i][ip, I...]
+        end
+
+        d = Inf # distance to the nearest vertex
+        particle_phase = -1
+        for offi in 0:1, offj in 0:1
+            ii, jj = I[1] + offi, I[2] + offj
+            !(ii ≤ ni[1]) && continue
+            !(jj ≤ ni[2]) && continue
+
+            xvᵢ = (xvi[1][ii], xvi[2][jj])
+            d_ijk = √(sum((pᵢ[i] - xvᵢ[i])^2 for i in 1:N))
+            if d_ijk < d
+                d = d_ijk
+                particle_phase = phase_grid[ii, jj]
+            end
+        end
+        @index phases[ip, I...] = Float64(particle_phase)
+    end
+
+    return nothing
+end
+```
+
 Now we assign the material phases from the arrays we computed with help of [GeophysicalModelGenerator.jl](https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl)
 ```julia
-phases_device    = PTArray(backend)(phases_GMG)
-phase_ratios     = PhaseRatios(backend, length(rheology), ni);
+phases_device    = PTArray(backend_JR)(phases_GMG)
+phase_ratios     = PhaseRatios(backend_JP, length(rheology), ni);
 init_phases!(pPhases, phases_device, particles, xvi)
 update_phase_ratios!(phase_ratios, particles, pPhases)
 ```
@@ -82,8 +140,8 @@ We need to copy the thermal field from the [GeophysicalModelGenerator.jl](https:
 ```julia
 Ttop             = 20 + 273
 Tbot             = maximum(T_GMG)
-thermal          = ThermalArrays(backend, ni)
-vertex2center!(thermal.T, PTArray(backend)(T_GMG); ghost_x = true, ghost_y = true)
+thermal          = ThermalArrays(backend_JR, ni)
+vertex2center!(thermal.T, PTArray(backend_JR)(T_GMG); ghost_x = true, ghost_y = true)
 thermal_bc       = TemperatureBoundaryConditions(;
     no_flux      = (left = true, right = true, top = false, bot = false),
     constant_value = (left = false, right = false, top = Ttop, bot = Tbot),
@@ -94,15 +152,21 @@ thermal_bcs!(thermal, thermal_bc)
 ## Instantiate Stokes arrays
 Stokes arrays object
 ```julia
-stokes           = StokesArrays(backend, ni)
-pt_stokes        = PTStokesCoeffs(li, di; ϵ_rel=1e-4, Re=3π, r=1e0, CFL = 0.98 / √2)
+stokes           = StokesArrays(backend_JR, ni)
+pt_stokes        = PTStokesCoeffs(li, di; ϵ_abs = 1e-4, ϵ_rel = 1e-4, Re = 1e0, r = 0.7, CFL = 0.9 / √2.1)
 ```
 
 ## Initialize buoyancy forces and lithostatic pressure
 ```julia
 ρg        = ntuple(_ -> @zeros(ni...), Val(2))
 compute_ρg!(ρg[2], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
-stokes.P .= PTArray(backend)(reverse(cumsum(reverse((ρg[2]).* di[2], dims=2), dims=2), dims=2))
+stokes.P .= PTArray(backend_JR)(reverse(cumsum(reverse((ρg[2]).* di[2], dims=2), dims=2), dims=2))
+```
+
+## Initialize viscosity
+```julia
+args = (T = thermal.T, P = stokes.P, dt = Inf)
+compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
 ```
 
 ## Define boundary conditions
@@ -113,25 +177,23 @@ flow_bcs         = VelocityBoundaryConditions(;
     free_slip    = (left = true , right = true , top = true , bot = true ),
     no_slip      = (left = false, right = false, top = false, bot = false),
 )
+flow_bcs!(stokes, flow_bcs) # apply boundary conditions
+update_halo!(@velocity(stokes)...)
 ```
 
 ## Pseuo-transient coefficients
 ```julia
 pt_thermal = PTThermalCoeffs(
-    backend, rheology, phase_ratios, args0, dt, ni, di, li; ϵ=1e-5, CFL=0.98 / √3
+    backend_JR, rheology, phase_ratios, args, dt, ni, di, li; ϵ = 1e-8, CFL = 0.95 / √2
 )
 ```
 
 ## Just before solving the problem...
-Because we have ghost nodes on the thermal field `thermal.T`, we need to copy the thermal field to a buffer array without those ghost nodes, and interpolate the temperature to the particles. This is because [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl) does not support ghost nodes in its current version.
+`thermal.T` is a cell-centered field surrounded by one ring of ghost nodes, which [JustPIC.jl](https://github.com/JuliaGeodynamics/JustPIC.jl) does not handle. We therefore keep a ghost-free buffer of the cell-centered temperature and use it for every exchange with the particles.
 ```julia
-T_buffer    = @zeros(ni.+1)
-Told_buffer = similar(T_buffer)
-dt₀         = similar(stokes.P)
-for (dst, src) in zip((T_buffer, Told_buffer), (thermal.T, thermal.Told))
-    copyinn_x!(dst, src)
-end
-grid2particle!(pT, T_buffer, particles)
+T_buffer = thermal.T[2:end-1, 2:end-1]
+dt₀      = similar(stokes.P)
+centroid2particle!(pT, T_buffer, particles)
 ```
 
 # Solving the problem
@@ -139,12 +201,10 @@ We will now advance the model in time, solving the Stokes and thermal equations,
 
 ## Advancing one time step
 
-1. Interpolate fields from particle to grid vertices
+1. Interpolate the temperature from the particles back to the cell centers
 ```julia
-particle2grid!(T_buffer, pT, particles)
-@views T_buffer[:, end]      .= Ttop
-@views T_buffer[:, 1]        .= Tbot
-@views thermal.T[2:end-1, :] .= T_buffer
+particle2centroid!(T_buffer, pT, particles)
+@views thermal.T[2:end-1, 2:end-1] .= T_buffer
 thermal_bcs!(thermal, thermal_bc)
 ```
 2. Solve stokes
@@ -153,17 +213,17 @@ thermal_bcs!(thermal, thermal_bc)
     out = solve!(
         stokes,
         pt_stokes,
-        di,
+        grid,
         flow_bcs,
         ρg,
         phase_ratios,
-        rheology_augmented,
+        rheology,
         args,
         dt,
         igg;
         kwargs = (
-            iterMax          = 150e3,
-            nout             = 1e3,
+            iterMax          = 100e3,
+            nout             = 2e3,
             viscosity_cutoff = viscosity_cutoff,
             free_surface     = false,
             viscosity_relaxation = 1e-2
@@ -173,6 +233,7 @@ end
 println("Stokes solver time             ")
 println("   Total time:      $t_stokes s")
 println("   Time/iteration:  $(t_stokes / out.iter) s")
+tensor_invariant!(stokes.ε)
 ```
 3. Update time step
 ```julia
@@ -185,10 +246,10 @@ heatdiffusion_PT!(
     thermal,
     pt_thermal,
     thermal_bc,
-    rheology_augmented,
+    rheology,
     args,
     dt,
-    di;
+    grid;
     kwargs = (
         igg     = igg,
         phase   = phase_ratios,
@@ -199,11 +260,11 @@ heatdiffusion_PT!(
 )
 # Subgrid diffusion
 subgrid_characteristic_time!(
-    subgrid_arrays, particles, dt₀, phase_ratios, rheology_augmented, thermal, stokes
+    subgrid_arrays, particles, dt₀, phase_ratios, rheology, thermal, stokes
 )
 centroid2particle!(subgrid_arrays.dt₀, dt₀, particles)
-subgrid_diffusion!(
-    pT, thermal.T, thermal.ΔT, subgrid_arrays, particles, dt
+subgrid_diffusion_centroid!(
+    pT, T_buffer, thermal.ΔT, subgrid_arrays, particles, dt
 )
 ```
 
@@ -225,8 +286,8 @@ Saving the particles will generate a lot of data so you might want to do this le
 if rem(it, 10) == 0
     checkpoint = joinpath(figdir, "checkpoint")
     take(checkpoint)
-    checkpointing_jld2(checkpoint, stokes, thermal, t, dt, igg; it = it)
-    checkpointing_particles(checkpoint, particles, igg.me; phases = pPhases, phase_ratios = phase_ratios, particle_args = particle_args, t = t, dt = dt, it = it)
+    checkpointing_jld2(checkpoint, stokes, thermal, t, dt; it = it)
+    checkpointing_particles(checkpoint, particles; phases = pPhases, phase_ratios = phase_ratios, particle_args = particle_args, t = t, dt = dt, it = it)
 end
 ```
 
@@ -236,14 +297,14 @@ Vx_v = @zeros(ni.+1...)
 Vy_v = @zeros(ni.+1...)
 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...) # interpolate velocity from staggered grid to vertices
 data_v = (; # data @ vertices
-    T   = Array(T_buffer),
-    τII = Array(stokes.τ.II),
-    εII = Array(stokes.ε.II),
     Vx  = Array(Vx_v),
     Vy  = Array(Vy_v),
 )
 data_c = (; # data @ centers
+    T   = Array(T_buffer),
     P   = Array(stokes.P),
+    τII = Array(stokes.τ.II),
+    εII = Array(stokes.ε.II),
     η   = Array(stokes.viscosity.η_vep),
 )
 velocity_v = ( # velocity vector field

--- a/miniapps/convection/Plume3D/Plume3D.jl
+++ b/miniapps/convection/Plume3D/Plume3D.jl
@@ -1,0 +1,451 @@
+# 3D thermal plume rising through a layered lithosphere.
+# Rheology after Cloetingh et al. (2022), "Fingerprinting secondary mantle plumes".
+
+const isCUDA = false
+
+@static if isCUDA
+    using CUDA
+end
+
+using JustRelax, JustRelax.JustRelax3D, JustRelax.DataIO
+using Pkg; Pkg.activate("miniapps")
+
+const backend_JR = @static if isCUDA
+    CUDABackend # Options: CPUBackend, CUDABackend, AMDGPUBackend
+else
+    JustRelax.CPUBackend
+end
+
+using ParallelStencil, ParallelStencil.FiniteDifferences3D
+
+@static if isCUDA
+    @init_parallel_stencil(CUDA, Float64, 3)
+else
+    @init_parallel_stencil(Threads, Float64, 3)
+end
+
+using JustPIC, JustPIC._3D
+
+const backend_JP = @static if isCUDA
+    CUDABackend # Options: JustPIC.CPUBackend, CUDABackend, JustPIC.AMDGPUBackend
+else
+    JustPIC.CPUBackend
+end
+
+using GeoParams, CairoMakie, Printf
+
+## RHEOLOGY -------------------------------------------------------------------------
+
+function init_rheologies()
+
+    # Dislocation and diffusion creep
+    disl_upper_crust = DislocationCreep(A = 5.07e-18, n = 2.3, E = 154.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_lower_crust = DislocationCreep(A = 2.08e-23, n = 3.2, E = 238.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_lithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 3.5, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_sublithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 3.5, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    diff_lithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 1.0, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    diff_sublithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 1.0, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+
+    # Elasticity
+    el_upper_crust = SetConstantElasticity(; G = 25.0e9, ν = 0.5)
+    el_lower_crust = SetConstantElasticity(; G = 25.0e9, ν = 0.5)
+    el_lithospheric_mantle = SetConstantElasticity(; G = 67.0e9, ν = 0.5)
+    el_sublithospheric_mantle = SetConstantElasticity(; G = 67.0e9, ν = 0.5)
+    β_upper_crust = inv(get_Kb(el_upper_crust))
+    β_lower_crust = inv(get_Kb(el_lower_crust))
+    β_lithospheric_mantle = inv(get_Kb(el_lithospheric_mantle))
+    β_sublithospheric_mantle = inv(get_Kb(el_sublithospheric_mantle))
+
+    # Regularised Drucker-Prager plasticity
+    η_reg = 1.0e16
+    cohesion = 3.0e6
+    pl_crust = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.2), η_vp = η_reg, Ψ = 0.0)
+    pl = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.3), η_vp = η_reg, Ψ = 0.0)
+
+    # Pressure- and temperature-dependent conductivities
+    K_crust = TP_Conductivity(; a = 0.64, b = 807.0e0, c = 0.77, d = 0.00004 * 1.0e-6)
+    K_mantle = TP_Conductivity(; a = 0.73, b = 1293.0e0, c = 0.77, d = 0.00004 * 1.0e-6)
+
+    return (
+        # Name              = "UpperCrust",
+        SetMaterialParams(;
+            Phase = 1,
+            Density = PT_Density(; ρ0 = 2.75e3, β = β_upper_crust, T0 = 0.0, α = 3.5e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 7.5e2),
+            Conductivity = K_crust,
+            CompositeRheology = CompositeRheology((disl_upper_crust, el_upper_crust, pl_crust)),
+            Elasticity = el_upper_crust,
+            Gravity = ConstantGravity(; g = 9.81),
+        ),
+        # Name              = "LowerCrust",
+        SetMaterialParams(;
+            Phase = 2,
+            Density = PT_Density(; ρ0 = 3.0e3, β = β_lower_crust, T0 = 0.0, α = 3.5e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 7.5e2),
+            Conductivity = K_crust,
+            CompositeRheology = CompositeRheology((disl_lower_crust, el_lower_crust, pl_crust)),
+            Elasticity = el_lower_crust,
+        ),
+        # Name              = "LithosphericMantle",
+        SetMaterialParams(;
+            Phase = 3,
+            Density = PT_Density(; ρ0 = 3.3e3, β = β_lithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_lithospheric_mantle, diff_lithospheric_mantle, el_lithospheric_mantle, pl)),
+            Elasticity = el_lithospheric_mantle,
+        ),
+        # Name              = "SubLithosphericMantle",
+        SetMaterialParams(;
+            Phase = 4,
+            Density = PT_Density(; ρ0 = 3.3e3, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_sublithospheric_mantle, diff_sublithospheric_mantle, el_sublithospheric_mantle)),
+            Elasticity = el_sublithospheric_mantle,
+        ),
+        # Name              = "Plume",
+        SetMaterialParams(;
+            Phase = 5,
+            Density = PT_Density(; ρ0 = 3.3e3 - 50, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_sublithospheric_mantle, diff_sublithospheric_mantle, el_sublithospheric_mantle)),
+            Elasticity = el_sublithospheric_mantle,
+        ),
+    )
+end
+
+## MODEL SETUP ----------------------------------------------------------------------
+
+# Layered lithosphere with a cubic plume of half-width `r` centered at depth `d`
+function init_phases!(phases, particles, Lx, Ly; d = 650.0e3, r = 50.0e3)
+    ni = size(phases)
+
+    @parallel_indices (I...) function _init_phases!(phases, px, py, pz, index, r, d, Lx, Ly)
+        for ip in cellaxes(phases)
+            # quick escape
+            @index(index[ip, I...]) == 0 && continue
+
+            x = @index px[ip, I...]
+            y = @index py[ip, I...]
+            depth = -(@index pz[ip, I...])
+
+            if 0.0e0 ≤ depth ≤ 21.0e3
+                @index phases[ip, I...] = 1.0
+
+            elseif 35.0e3 ≥ depth > 21.0e3
+                @index phases[ip, I...] = 2.0
+
+            elseif 90.0e3 ≥ depth > 35.0e3
+                @index phases[ip, I...] = 3.0
+
+            elseif depth > 90.0e3
+                @index phases[ip, I...] = 4.0
+
+            end
+
+            # plume - rectangular
+            if ((x - Lx * 0.5)^2 ≤ r^2) && ((y - Ly * 0.5)^2 ≤ r^2) && ((depth - d)^2 ≤ r^2)
+                @index phases[ip, I...] = 5.0
+            end
+        end
+        return nothing
+    end
+
+    return @parallel (@idx ni) _init_phases!(phases, particles.coords..., particles.index, r, d, Lx, Ly)
+end
+
+# Piecewise-linear geotherm
+@parallel_indices (I...) function init_T!(T, z)
+    depth = -z[I[3]]
+
+    if depth < 0.0e0
+        T[I...] = 273.0
+
+    elseif 0.0e0 ≤ depth < 35.0e3
+        dTdZ = (923 - 273) / 35.0e3
+        offset = 273.0e0
+        T[I...] = depth * dTdZ + offset
+
+    elseif 110.0e3 > depth ≥ 35.0e3
+        dTdZ = (1492 - 923) / 75.0e3
+        offset = 923.0e0
+        T[I...] = (depth - 35.0e3) * dTdZ + offset
+
+    elseif depth ≥ 110.0e3
+        dTdZ = (1837 - 1492) / 590.0e3
+        offset = 1492.0e0
+        T[I...] = (depth - 110.0e3) * dTdZ + offset
+
+    end
+
+    return nothing
+end
+
+# Thermal rectangular perturbation
+function rectangular_perturbation!(T, xc, yc, zc, r, xvi)
+
+    @parallel_indices (i, j, k) function _rectangular_perturbation!(T, xc, yc, zc, r, x, y, z)
+        if (abs(x[i] - xc) ≤ r) && (abs(y[j] - yc) ≤ r) && (abs(z[k] - zc) ≤ r)
+            depth = abs(z[k])
+            dTdZ = (2047 - 2017) / 50.0e3
+            offset = 2017
+            T[i, j, k] = (depth - 585.0e3) * dTdZ + offset
+        end
+        return nothing
+    end
+
+    return @parallel _rectangular_perturbation!(T, xc, yc, zc, r, xvi...)
+end
+
+## MAIN SCRIPT ----------------------------------------------------------------------
+
+function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_vtk = false)
+
+    # Physical domain ------------------------------------
+    lz = 700.0e3              # domain length in z
+    lx = ly = lz * ar         # domain length in x and y
+    ni = nx, ny, nz           # number of cells
+    li = lx, ly, lz           # domain length
+    di = @. li / ni           # grid steps
+    origin = 0.0, 0.0, -lz    # origin coordinates
+    grid = Geometry(ni, li; origin = origin)
+    (; xci, xvi) = grid       # nodes at the center and vertices of the cells
+    # ----------------------------------------------------
+
+    # Physical properties using GeoParams ----------------
+    rheology = init_rheologies()
+    κ = 10 / (rheology[1].HeatCapacity[1].Cp * rheology[1].Density[1].ρ0)
+    dt = dt_diff = 0.5 * min(di...)^3 / κ / 3.01 # diffusive CFL timestep limiter
+    # ----------------------------------------------------
+
+    # Initialize particles -------------------------------
+    nxcell, max_xcell, min_xcell = 25, 35, 8
+    particles = init_particles(backend_JP, nxcell, max_xcell, min_xcell, grid.xi_vel...)
+    subgrid_arrays = SubgridDiffusionCellArrays(particles; loc = :center)
+    # temperature and material phase carried by the particles
+    pT, pPhases = init_cell_arrays(particles, Val(2))
+    particle_args = (pT, pPhases)
+
+    # Rectangular thermal and compositional anomaly
+    xc_anomaly = lx / 2   # origin of thermal anomaly
+    yc_anomaly = ly / 2   # origin of thermal anomaly
+    zc_anomaly = -610.0e3 # origin of thermal anomaly
+    r_anomaly = 50.0e3    # radius of perturbation
+    init_phases!(pPhases, particles, lx, ly; d = abs(zc_anomaly), r = r_anomaly)
+    phase_ratios = PhaseRatios(backend_JP, length(rheology), ni)
+    update_phase_ratios!(phase_ratios, particles, pPhases)
+    # ----------------------------------------------------
+
+    # STOKES ---------------------------------------------
+    stokes = StokesArrays(backend_JR, ni)
+    pt_stokes = PTStokesCoeffs(li, di; ϵ_abs = 1.0e-4, ϵ_rel = 1.0e-4, Re = 3π, r = 1.0e0, CFL = 0.9 / √3.1)
+    # ----------------------------------------------------
+
+    # TEMPERATURE PROFILE --------------------------------
+    thermal = ThermalArrays(backend_JR, ni)
+    thermal_bc = TemperatureBoundaryConditions(;
+        no_flux = (left = true, right = true, top = false, bot = false, front = true, back = true),
+    )
+    # initialize the geotherm on the vertices, then transfer it to the centroids of `thermal.T`
+    T_vertex = @zeros(ni .+ 1...)
+    @parallel (@idx ni .+ 1) init_T!(T_vertex, xvi[3])
+    rectangular_perturbation!(T_vertex, xc_anomaly, yc_anomaly, zc_anomaly, r_anomaly, xvi)
+    vertex2center!(thermal.T, T_vertex; ghost_x = true, ghost_y = true, ghost_z = true)
+    thermal_bcs!(thermal, thermal_bc)
+    # ----------------------------------------------------
+
+    # Buoyancy forces and lithostatic pressure
+    ρg = ntuple(_ -> @zeros(ni...), Val(3))
+    compute_ρg!(ρg[end], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
+    stokes.P .= PTArray(backend_JR)(reverse(cumsum(reverse(ρg[end] .* di[end], dims = 3), dims = 3), dims = 3))
+
+    # Rheology
+    args = (; T = thermal.T, P = stokes.P, dt = Inf)
+    viscosity_cutoff = (1.0e18, 1.0e24)
+    compute_viscosity!(stokes, phase_ratios, args, rheology, viscosity_cutoff)
+
+    # PT coefficients for thermal diffusion
+    pt_thermal = PTThermalCoeffs(
+        backend_JR, rheology, phase_ratios, args, dt, ni, di, li; ϵ = 1.0e-5, CFL = 0.95 / √3
+    )
+
+    # Free slip on every wall
+    flow_bcs = VelocityBoundaryConditions(;
+        free_slip = (left = true, right = true, top = true, bot = true, front = true, back = true),
+        no_slip = (left = false, right = false, top = false, bot = false, front = false, back = false),
+    )
+    flow_bcs!(stokes, flow_bcs) # apply boundary conditions
+    update_halo!(@velocity(stokes)...)
+
+    # IO -------------------------------------------------
+    if do_vtk
+        vtk_dir = joinpath(figdir, "vtk")
+        take(vtk_dir)
+    end
+    take(figdir)
+    # ----------------------------------------------------
+
+    T_buffer = thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)]
+    centroid2particle!(pT, T_buffer, particles)
+    dt₀ = similar(stokes.P)
+
+    local Vx_v, Vy_v, Vz_v
+    if do_vtk
+        Vx_v = @zeros(ni .+ 1...)
+        Vy_v = @zeros(ni .+ 1...)
+        Vz_v = @zeros(ni .+ 1...)
+    end
+
+    # Time loop
+    t, it = 0.0, 0
+    while (t / (1.0e6 * 3600 * 24 * 365.25)) < 5 # run only for 5 Myrs
+
+        # interpolate fields from particles to centroids
+        particle2centroid!(T_buffer, pT, particles)
+        @views thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)] .= T_buffer
+        thermal_bcs!(thermal, thermal_bc)
+        # ------------------------------
+
+        # Stokes solver ----------------
+        t_stokes = @elapsed begin
+            out = solve!(
+                stokes,
+                pt_stokes,
+                grid,
+                flow_bcs,
+                ρg,
+                phase_ratios,
+                rheology,
+                args,
+                Inf,
+                igg;
+                kwargs = (;
+                    iterMax = 100.0e3,
+                    nout = 1.0e3,
+                    viscosity_cutoff = viscosity_cutoff,
+                )
+            )
+        end
+        println("Stokes solver time             ")
+        println("   Total time:      $t_stokes s")
+        println("   Time/iteration:  $(t_stokes / out.iter) s")
+        tensor_invariant!(stokes.ε)
+        dt = compute_dt(stokes, di, dt_diff) * 0.8
+        # ------------------------------
+
+        # Thermal solver ---------------
+        heatdiffusion_PT!(
+            thermal,
+            pt_thermal,
+            thermal_bc,
+            rheology,
+            args,
+            dt,
+            grid;
+            kwargs = (;
+                igg = igg,
+                phase = phase_ratios,
+                iterMax = 50.0e3,
+                nout = 1.0e2,
+                verbose = true,
+            )
+        )
+        subgrid_characteristic_time!(
+            subgrid_arrays, particles, dt₀, phase_ratios, rheology, thermal, stokes
+        )
+        centroid2particle!(subgrid_arrays.dt₀, dt₀, particles)
+        subgrid_diffusion_centroid!(
+            pT, T_buffer, thermal.ΔT, subgrid_arrays, particles, dt
+        )
+        # ------------------------------
+
+        # Advection --------------------
+        # advect particles in space
+        advection_MQS!(particles, RungeKutta2(), @velocity(stokes), dt)
+        # advect particles in memory
+        move_particles!(particles, particle_args)
+        # check if we need to inject particles
+        inject_particles_phase!(particles, pPhases, (pT,), (T_buffer,))
+        # update phase ratios
+        update_phase_ratios!(phase_ratios, particles, pPhases)
+
+        it += 1
+        t += dt
+        @printf("it = %d, t = %.3f Myrs, dt = %.3f kyrs\n", it, t / (1.0e6 * 3600 * 24 * 365.25), dt / (1.0e3 * 3600 * 24 * 365.25))
+
+        # Data I/O and plotting ---------------------
+        if it == 1 || rem(it, 10) == 0
+            checkpointing_hdf5(figdir, stokes, thermal.T, t, dt)
+
+            if do_vtk
+                velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
+                data_v = (;
+                    T = Array(T_vertex),
+                )
+                data_c = (;
+                    T = Array(T_buffer),
+                    P = Array(stokes.P),
+                    τII = Array(stokes.τ.II),
+                    εII = Array(stokes.ε.II),
+                    η = Array(log10.(stokes.viscosity.η_vep)),
+                    phase = [argmax(p) for p in Array(phase_ratios.center)],
+                )
+                velocity_v = (
+                    Array(Vx_v),
+                    Array(Vy_v),
+                    Array(Vz_v),
+                )
+                save_vtk(
+                    joinpath(vtk_dir, "vtk_" * lpad("$it", 6, "0")),
+                    xvi,
+                    xci,
+                    data_v,
+                    data_c,
+                    velocity_v,
+                    t = t
+                )
+            end
+
+            # vertical slice through the middle of the plume
+            slice_j = ny >>> 1
+            fig = Figure(size = (1400, 1200))
+            ax1 = Axis(fig[1, 1], aspect = ar, title = "T [K]  (t=$(t / (1.0e6 * 3600 * 24 * 365.25)) Myrs)")
+            ax2 = Axis(fig[2, 1], aspect = ar, title = "τII [MPa]")
+            ax3 = Axis(fig[1, 3], aspect = ar, title = "log10(εII)")
+            ax4 = Axis(fig[2, 3], aspect = ar, title = "log10(η)")
+            h1 = heatmap!(ax1, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(T_buffer[:, slice_j, :]), colormap = :lajolla)
+            h2 = heatmap!(ax2, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(stokes.τ.II[:, slice_j, :] .* 1.0e-6), colormap = :batlow)
+            h3 = heatmap!(ax3, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(log10.(stokes.ε.II[:, slice_j, :])), colormap = :batlow)
+            h4 = heatmap!(ax4, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(log10.(stokes.viscosity.η_vep[:, slice_j, :])), colormap = :batlow)
+            hideydecorations!(ax3)
+            hideydecorations!(ax4)
+            Colorbar(fig[1, 2], h1)
+            Colorbar(fig[2, 2], h2)
+            Colorbar(fig[1, 4], h3)
+            Colorbar(fig[2, 4], h4)
+            linkaxes!(ax1, ax2, ax3, ax4)
+            save(joinpath(figdir, "$(it).png"), fig)
+        end
+        # ------------------------------
+break
+    end
+
+    return nothing
+end
+
+## SCRIPT ENTRY POINT ---------------------------------------------------------------
+
+do_vtk = true  # set to true to generate VTK files for ParaView
+ar = 1         # aspect ratio
+n = 32
+nx = ny = nz = n
+igg = if !(JustRelax.MPI.Initialized()) # initialize (or not) MPI grid
+    IGG(init_global_grid(nx, ny, nz; init_MPI = true)...)
+else
+    igg
+end
+
+figdir = "Plume3D_$n"
+main3D(igg; figdir = figdir, ar = ar, nx = nx, ny = ny, nz = nz, do_vtk = do_vtk)

--- a/miniapps/convection/Plume3D/Plume3D.jl
+++ b/miniapps/convection/Plume3D/Plume3D.jl
@@ -429,7 +429,6 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
             save(joinpath(figdir, "$(it).png"), fig)
         end
         # ------------------------------
-break
     end
 
     return nothing


### PR DESCRIPTION
The example walkthroughs in `docs/src/man` had drifted from the solver interface. I extracted every ```julia block from each page and ran them in order; the 3D plume, 2D subduction, shear-band and Blankenbach examples all failed. They now execute end to end.

## What was wrong

**Temperature discretization (all four examples).** `thermal.T` is cell-centered with one ring of ghost nodes, but the pages still used the old vertex-based scheme: `T_buffer = @zeros(ni.+1)`, `copyinn_x!`, `grid2particle!` / `particle2grid!` and `subgrid_diffusion!`. They now build the profile on the vertices and transfer it with `vertex2center!`, keep a ghost-free centroid buffer for the particle exchange, and use `centroid2particle!` / `particle2centroid!` / `subgrid_diffusion_centroid!` with `SubgridDiffusionCellArrays(...; loc = :center)`.

**Signatures.** `solve!` and `heatdiffusion_PT!` were passed `di`; they take the `Geometry`. `compute_viscosity!(stokes, 1.0, phase_ratios, …)` has no method — relaxation is a keyword now. `Geometry(xv, yv)` is not a method; the nonuniform constructor takes a tuple.

**Crashes.**
- `ShearBands.md`: `args.T` was `@zeros(ni...)` instead of the ghosted `@zeros(ni .+ 2...)` → `BoundsError`.
- `subduction2D`: the GeophysicalModelGenerator grid was `512×218` while the model was `256×128`. Those arrays hold *vertices*, so they need cells+1; mismatched sizes make `vertex2center!` throw. Now `257×129`, with the relation stated in the text.

**Silently wrong.** `Blankenbach.md` initialized the geotherm with `@parallel (@idx ni) init_T!((thermal.T[2:end-1, 2:end-1]), xci[2])` — the slice materializes a copy, so the result was written to a temporary and discarded. It now writes into `thermal.T` with an offset. Its two "alternative one-liners" for phase initialization called `isnan` on `particles.index`, which is a `Bool` cell array; replaced with boolean masks.

**Undefined names.** `rheology_augmented`, `args0`, `η_reg`, `ar`, `viscosity_cutoff`, `dt`, and `init_phases!` were referenced but never defined; `using GeoParams` was never loaded in the subduction page; `flow_bcs!` and `compute_viscosity!` were missing from its setup. `subduction2D.md` also defined `backend_JR` and then handed the *JustPIC* backend to `StokesArrays`, `ThermalArrays` and `PTArray`.

**Plume rheology.** `init_phases!` assigns phase `5` to the plume, but the rheology page only defined four phases. Phase 4 is now plain sublithospheric mantle and phase 5 is the plume, 50 kg/m³ lighter — the density contrast that drives the upwelling.

## New file

`miniapps/convection/Plume3D/Plume3D.jl` — the runnable, self-contained script that the 3D plume walkthrough describes, which had no counterpart in `miniapps/`. Smoke-tested at 8³.

## Verification

Each example was run as a script against JustRelax at this branch. Only two harness adjustments were needed, both inherent to the page format rather than the API: the top-level `for` loops in `ShearBands.md` and `Blankenbach.md` assign to globals, which works when pasted into a REPL but needs `global` in a script. I left those pages as they are — say the word if you'd rather they were wrapped in functions like the miniapps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
