### PR TITLE
MPI plume miniapp, and fix the MPI subduction miniapps

### DIFF
--- a/miniapps/convection/Plume3D/Plume3D_MPI.jl
+++ b/miniapps/convection/Plume3D/Plume3D_MPI.jl
@@ -1,5 +1,8 @@
-# 3D thermal plume rising through a layered lithosphere.
+# Distributed-memory version of Plume3D.jl.
 # Rheology after Cloetingh et al. (2022), "Fingerprinting secondary mantle plumes".
+#
+# Run with, e.g.
+#   mpiexecjl -n 8 julia --project=miniapps miniapps/convection/Plume3D/Plume3D_MPI.jl
 
 const isCUDA = false
 
@@ -32,23 +35,38 @@ else
     JustPIC.CPUBackend
 end
 
-using GeoParams, CairoMakie, Printf
+using GeoParams, Printf
 
 include("Plume3D_rheology.jl")
 
+import ParallelStencil.INDICES
+const idx_k = INDICES[3]
+macro all_k(A)
+    return esc(:($A[$idx_k]))
+end
+
+# Lithostatic pressure from the local column. `z` holds global coordinates, so this is
+# the same profile on every rank; a cumulative sum along z would only see one subdomain.
+@parallel function init_P!(P, ρg, z)
+    @all(P) = abs(@all(ρg) * @all_k(z)) * <(@all_k(z), 0.0)
+    return nothing
+end
+
 ## MAIN SCRIPT ----------------------------------------------------------------------
 
-function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_vtk = false)
+function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D_MPI", do_vtk = false)
 
     # Physical domain ------------------------------------
-    lz = 700.0e3              # domain length in z
-    lx = ly = lz * ar         # domain length in x and y
-    ni = nx, ny, nz           # number of cells
-    li = lx, ly, lz           # domain length
-    di = @. li / ni           # grid steps
-    origin = 0.0, 0.0, -lz    # origin coordinates
+    # `li` and `origin` describe the *global* domain; `ni` is the number of cells of
+    # this rank, and `Geometry` returns the coordinates of its subdomain.
+    lz = 700.0e3                          # domain length in z
+    lx = ly = lz * ar                     # domain length in x and y
+    ni = nx, ny, nz                       # number of local cells
+    li = lx, ly, lz                       # global domain length
+    di = @. li / (nx_g(), ny_g(), nz_g()) # grid steps
+    origin = 0.0, 0.0, -lz                # origin coordinates
     grid = Geometry(ni, li; origin = origin)
-    (; xci, xvi) = grid       # nodes at the center and vertices of the cells
+    (; xci, xvi) = grid                   # nodes at the center and vertices of the cells
     # ----------------------------------------------------
 
     # Physical properties using GeoParams ----------------
@@ -73,6 +91,9 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
     init_phases!(pPhases, particles, lx, ly; d = abs(zc_anomaly), r = r_anomaly)
     phase_ratios = PhaseRatios(backend_JP, length(rheology), ni)
     update_phase_ratios!(phase_ratios, particles, pPhases)
+
+    update_cell_halo!(particles.coords..., particle_args...)
+    update_cell_halo!(particles.index)
     # ----------------------------------------------------
 
     # STOKES ---------------------------------------------
@@ -91,12 +112,13 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
     rectangular_perturbation!(T_vertex, xc_anomaly, yc_anomaly, zc_anomaly, r_anomaly, xvi)
     vertex2center!(thermal.T, T_vertex; ghost_x = true, ghost_y = true, ghost_z = true)
     thermal_bcs!(thermal, thermal_bc)
+    update_halo!(thermal.T)
     # ----------------------------------------------------
 
     # Buoyancy forces and lithostatic pressure
     ρg = ntuple(_ -> @zeros(ni...), Val(3))
     compute_ρg!(ρg[end], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
-    stokes.P .= PTArray(backend_JR)(reverse(cumsum(reverse(ρg[end] .* di[end], dims = 3), dims = 3), dims = 3))
+    @parallel (@idx ni) init_P!(stokes.P, ρg[end], xci[3])
 
     # Rheology
     args = (; T = thermal.T, P = stokes.P, dt = Inf)
@@ -117,23 +139,48 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
     update_halo!(@velocity(stokes)...)
 
     # IO -------------------------------------------------
-    if do_vtk
-        vtk_dir = joinpath(figdir, "vtk")
-        take(vtk_dir)
+    if igg.me == 0
+        do_vtk && take(joinpath(figdir, "vtk"))
+        take(figdir)
     end
-    take(figdir)
+    vtk_dir = joinpath(figdir, "vtk")
     # ----------------------------------------------------
 
     T_buffer = thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)]
     centroid2particle!(pT, T_buffer, particles)
     dt₀ = similar(stokes.P)
 
-    local Vx_v, Vy_v, Vz_v
-    if do_vtk
-        Vx_v = @zeros(ni .+ 1...)
-        Vy_v = @zeros(ni .+ 1...)
-        Vz_v = @zeros(ni .+ 1...)
-    end
+    # Buffers for the MPI gather. Each rank contributes its subdomain minus the halo,
+    # so the assembled arrays are (n - 2) * dims cells wide in each direction.
+    nx_v, ny_v, nz_v = (nx - 2) * igg.dims[1], (ny - 2) * igg.dims[2], (nz - 2) * igg.dims[3]
+    T_v = zeros(nx_v, ny_v, nz_v)
+    P_v = zeros(nx_v, ny_v, nz_v)
+    τII_v = zeros(nx_v, ny_v, nz_v)
+    εII_v = zeros(nx_v, ny_v, nz_v)
+    η_vep_v = zeros(nx_v, ny_v, nz_v)
+    phases_v = zeros(nx_v, ny_v, nz_v)
+    Vx_g = zeros(nx_v, ny_v, nz_v)
+    Vy_g = zeros(nx_v, ny_v, nz_v)
+    Vz_g = zeros(nx_v, ny_v, nz_v)
+
+    T_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    P_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    τII_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    εII_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    η_vep_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    phases_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    Vx_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    Vy_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+    Vz_nohalo = zeros(nx - 2, ny - 2, nz - 2)
+
+    xci_v = ntuple(i -> LinRange(origin[i], origin[i] + li[i], (i == 1 ? nx_v : i == 2 ? ny_v : nz_v)), Val(3))
+
+    Vx_v = @zeros(ni .+ 1...)
+    Vy_v = @zeros(ni .+ 1...)
+    Vz_v = @zeros(ni .+ 1...)
+    Vx_c = @zeros(ni...)
+    Vy_c = @zeros(ni...)
+    Vz_c = @zeros(ni...)
 
     # Time loop
     t, it = 0.0, 0
@@ -143,6 +190,7 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
         particle2centroid!(T_buffer, pT, particles)
         @views thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)] .= T_buffer
         thermal_bcs!(thermal, thermal_bc)
+        update_halo!(thermal.T)
         # ------------------------------
 
         # Stokes solver ----------------
@@ -165,11 +213,15 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
                 )
             )
         end
-        println("Stokes solver time             ")
-        println("   Total time:      $t_stokes s")
-        println("   Time/iteration:  $(t_stokes / out.iter) s")
+        if igg.me == 0
+            println("Stokes solver time             ")
+            println("   Total time:      $t_stokes s")
+            println("   Time/iteration:  $(t_stokes / out.iter) s")
+        end
         tensor_invariant!(stokes.ε)
-        dt = compute_dt(stokes, di, dt_diff) * 0.8
+        # `igg` makes the velocity maximum a global reduction, so every rank marches
+        # with the same dt
+        dt = compute_dt(stokes, di, dt_diff, igg) * 0.8
         # ------------------------------
 
         # Thermal solver ---------------
@@ -186,7 +238,7 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
                 phase = phase_ratios,
                 iterMax = 50.0e3,
                 nout = 1.0e2,
-                verbose = true,
+                verbose = igg.me == 0,
             )
         )
         subgrid_characteristic_time!(
@@ -201,6 +253,9 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
         # Advection --------------------
         # advect particles in space
         advection_MQS!(particles, RungeKutta2(), @velocity(stokes), dt)
+        # exchange the particles that crossed a subdomain boundary
+        update_cell_halo!(particles.coords..., particle_args...)
+        update_cell_halo!(particles.index)
         # advect particles in memory
         move_particles!(particles, particle_args)
         # check if we need to inject particles
@@ -210,64 +265,62 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "Plume3D", do_v
 
         it += 1
         t += dt
-        @printf("it = %d, t = %.3f Myrs, dt = %.3f kyrs\n", it, t / (1.0e6 * 3600 * 24 * 365.25), dt / (1.0e3 * 3600 * 24 * 365.25))
+        igg.me == 0 && @printf(
+            "it = %d, t = %.3f Myrs, dt = %.3f kyrs\n",
+            it, t / (1.0e6 * 3600 * 24 * 365.25), dt / (1.0e3 * 3600 * 24 * 365.25)
+        )
 
-        # Data I/O and plotting ---------------------
-        if it == 1 || rem(it, 10) == 0
-            checkpointing_hdf5(figdir, stokes, thermal.T, t, dt)
+        # Data I/O ---------------------
+        if do_vtk && (it == 1 || rem(it, 10) == 0)
+            velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
+            vertex2center!(Vx_c, Vx_v)
+            vertex2center!(Vy_c, Vy_v)
+            vertex2center!(Vz_c, Vz_v)
+            phase_center = [argmax(p) for p in Array(phase_ratios.center)]
 
-            if do_vtk
-                velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
-                data_v = (;
-                    T = Array(T_vertex),
-                )
+            @views T_nohalo .= Array(T_buffer[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views P_nohalo .= Array(stokes.P[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views τII_nohalo .= Array(stokes.τ.II[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views εII_nohalo .= Array(stokes.ε.II[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views η_vep_nohalo .= Array(stokes.viscosity.η_vep[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views phases_nohalo .= phase_center[2:(end - 1), 2:(end - 1), 2:(end - 1)]
+            @views Vx_nohalo .= Array(Vx_c[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views Vy_nohalo .= Array(Vy_c[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+            @views Vz_nohalo .= Array(Vz_c[2:(end - 1), 2:(end - 1), 2:(end - 1)])
+
+            gather!(T_nohalo, T_v)
+            gather!(P_nohalo, P_v)
+            gather!(τII_nohalo, τII_v)
+            gather!(εII_nohalo, εII_v)
+            gather!(η_vep_nohalo, η_vep_v)
+            gather!(phases_nohalo, phases_v)
+            gather!(Vx_nohalo, Vx_g)
+            gather!(Vy_nohalo, Vy_g)
+            gather!(Vz_nohalo, Vz_g)
+
+            if igg.me == 0
                 data_c = (;
-                    T = Array(T_buffer),
-                    P = Array(stokes.P),
-                    τII = Array(stokes.τ.II),
-                    εII = Array(stokes.ε.II),
-                    η = Array(log10.(stokes.viscosity.η_vep)),
-                    phase = [argmax(p) for p in Array(phase_ratios.center)],
-                )
-                velocity_v = (
-                    Array(Vx_v),
-                    Array(Vy_v),
-                    Array(Vz_v),
+                    T = T_v,
+                    P = P_v,
+                    τII = τII_v,
+                    εII = εII_v,
+                    η = log10.(η_vep_v),
+                    phase = phases_v,
                 )
                 save_vtk(
                     joinpath(vtk_dir, "vtk_" * lpad("$it", 6, "0")),
-                    xvi,
-                    xci,
-                    data_v,
+                    xci_v,
                     data_c,
-                    velocity_v,
+                    (Vx_g, Vy_g, Vz_g);
                     t = t
                 )
             end
-
-            # vertical slice through the middle of the plume
-            slice_j = ny >>> 1
-            fig = Figure(size = (1400, 1200))
-            ax1 = Axis(fig[1, 1], aspect = ar, title = "T [K]  (t=$(t / (1.0e6 * 3600 * 24 * 365.25)) Myrs)")
-            ax2 = Axis(fig[2, 1], aspect = ar, title = "τII [MPa]")
-            ax3 = Axis(fig[1, 3], aspect = ar, title = "log10(εII)")
-            ax4 = Axis(fig[2, 3], aspect = ar, title = "log10(η)")
-            h1 = heatmap!(ax1, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(T_buffer[:, slice_j, :]), colormap = :lajolla)
-            h2 = heatmap!(ax2, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(stokes.τ.II[:, slice_j, :] .* 1.0e-6), colormap = :batlow)
-            h3 = heatmap!(ax3, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(log10.(stokes.ε.II[:, slice_j, :])), colormap = :batlow)
-            h4 = heatmap!(ax4, xci[1] .* 1.0e-3, xci[3] .* 1.0e-3, Array(log10.(stokes.viscosity.η_vep[:, slice_j, :])), colormap = :batlow)
-            hideydecorations!(ax3)
-            hideydecorations!(ax4)
-            Colorbar(fig[1, 2], h1)
-            Colorbar(fig[2, 2], h2)
-            Colorbar(fig[1, 4], h3)
-            Colorbar(fig[2, 4], h4)
-            linkaxes!(ax1, ax2, ax3, ax4)
-            save(joinpath(figdir, "$(it).png"), fig)
         end
         # ------------------------------
+
     end
 
+    finalize_global_grid()
     return nothing
 end
 
@@ -275,7 +328,7 @@ end
 
 do_vtk = true  # set to true to generate VTK files for ParaView
 ar = 1         # aspect ratio
-n = 32
+n = 32         # number of cells per direction and per rank
 nx = ny = nz = n
 igg = if !(JustRelax.MPI.Initialized()) # initialize (or not) MPI grid
     IGG(init_global_grid(nx, ny, nz; init_MPI = true)...)
@@ -283,5 +336,5 @@ else
     igg
 end
 
-figdir = "Plume3D_$n"
+figdir = "Plume3D_MPI_$(nx_g())x$(ny_g())x$(nz_g())"
 main3D(igg; figdir = figdir, ar = ar, nx = nx, ny = ny, nz = nz, do_vtk = do_vtk)

--- a/miniapps/convection/Plume3D/Plume3D_rheology.jl
+++ b/miniapps/convection/Plume3D/Plume3D_rheology.jl
@@ -1,0 +1,168 @@
+# Model definition shared by Plume3D.jl and Plume3D_MPI.jl.
+# Rheology after Cloetingh et al. (2022), "Fingerprinting secondary mantle plumes".
+#
+# Include this after `@init_parallel_stencil` and `using JustPIC._3D`: the kernels below
+# need both.
+
+function init_rheologies()
+
+    # Dislocation and diffusion creep
+    disl_upper_crust = DislocationCreep(A = 5.07e-18, n = 2.3, E = 154.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_lower_crust = DislocationCreep(A = 2.08e-23, n = 3.2, E = 238.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_lithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 3.5, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    disl_sublithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 3.5, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    diff_lithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 1.0, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+    diff_sublithospheric_mantle = DislocationCreep(A = 2.51e-17, n = 1.0, E = 530.0e3, V = 6.0e-6, r = 0.0, R = 8.3145)
+
+    # Elasticity
+    el_upper_crust = SetConstantElasticity(; G = 25.0e9, ν = 0.5)
+    el_lower_crust = SetConstantElasticity(; G = 25.0e9, ν = 0.5)
+    el_lithospheric_mantle = SetConstantElasticity(; G = 67.0e9, ν = 0.5)
+    el_sublithospheric_mantle = SetConstantElasticity(; G = 67.0e9, ν = 0.5)
+    β_upper_crust = inv(get_Kb(el_upper_crust))
+    β_lower_crust = inv(get_Kb(el_lower_crust))
+    β_lithospheric_mantle = inv(get_Kb(el_lithospheric_mantle))
+    β_sublithospheric_mantle = inv(get_Kb(el_sublithospheric_mantle))
+
+    # Regularised Drucker-Prager plasticity
+    η_reg = 1.0e16
+    cohesion = 3.0e6
+    pl_crust = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.2), η_vp = η_reg, Ψ = 0.0)
+    pl = DruckerPrager_regularised(; C = cohesion, ϕ = asind(0.3), η_vp = η_reg, Ψ = 0.0)
+
+    # Pressure- and temperature-dependent conductivities
+    K_crust = TP_Conductivity(; a = 0.64, b = 807.0e0, c = 0.77, d = 0.00004 * 1.0e-6)
+    K_mantle = TP_Conductivity(; a = 0.73, b = 1293.0e0, c = 0.77, d = 0.00004 * 1.0e-6)
+
+    return (
+        # Name              = "UpperCrust",
+        SetMaterialParams(;
+            Phase = 1,
+            Density = PT_Density(; ρ0 = 2.75e3, β = β_upper_crust, T0 = 0.0, α = 3.5e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 7.5e2),
+            Conductivity = K_crust,
+            CompositeRheology = CompositeRheology((disl_upper_crust, el_upper_crust, pl_crust)),
+            Elasticity = el_upper_crust,
+            Gravity = ConstantGravity(; g = 9.81),
+        ),
+        # Name              = "LowerCrust",
+        SetMaterialParams(;
+            Phase = 2,
+            Density = PT_Density(; ρ0 = 3.0e3, β = β_lower_crust, T0 = 0.0, α = 3.5e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 7.5e2),
+            Conductivity = K_crust,
+            CompositeRheology = CompositeRheology((disl_lower_crust, el_lower_crust, pl_crust)),
+            Elasticity = el_lower_crust,
+        ),
+        # Name              = "LithosphericMantle",
+        SetMaterialParams(;
+            Phase = 3,
+            Density = PT_Density(; ρ0 = 3.3e3, β = β_lithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_lithospheric_mantle, diff_lithospheric_mantle, el_lithospheric_mantle, pl)),
+            Elasticity = el_lithospheric_mantle,
+        ),
+        # Name              = "SubLithosphericMantle",
+        SetMaterialParams(;
+            Phase = 4,
+            Density = PT_Density(; ρ0 = 3.3e3, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_sublithospheric_mantle, diff_sublithospheric_mantle, el_sublithospheric_mantle)),
+            Elasticity = el_sublithospheric_mantle,
+        ),
+        # Name              = "Plume", 50 kg/m³ lighter than the sublithospheric mantle
+        SetMaterialParams(;
+            Phase = 5,
+            Density = PT_Density(; ρ0 = 3.3e3 - 50, β = β_sublithospheric_mantle, T0 = 0.0, α = 3.0e-5),
+            HeatCapacity = ConstantHeatCapacity(; Cp = 1.25e3),
+            Conductivity = K_mantle,
+            CompositeRheology = CompositeRheology((disl_sublithospheric_mantle, diff_sublithospheric_mantle, el_sublithospheric_mantle)),
+            Elasticity = el_sublithospheric_mantle,
+        ),
+    )
+end
+
+# Layered lithosphere with a cubic plume of half-width `r` centered at depth `d`.
+# The particle coordinates are global, so under MPI every rank builds the part of the
+# model that falls inside its own subdomain without any extra bookkeeping.
+function init_phases!(phases, particles, Lx, Ly; d = 650.0e3, r = 50.0e3)
+    ni = size(phases)
+
+    @parallel_indices (I...) function _init_phases!(phases, px, py, pz, index, r, d, Lx, Ly)
+        for ip in cellaxes(phases)
+            # quick escape
+            @index(index[ip, I...]) == 0 && continue
+
+            x = @index px[ip, I...]
+            y = @index py[ip, I...]
+            depth = -(@index pz[ip, I...])
+
+            if 0.0e0 ≤ depth ≤ 21.0e3
+                @index phases[ip, I...] = 1.0
+
+            elseif 35.0e3 ≥ depth > 21.0e3
+                @index phases[ip, I...] = 2.0
+
+            elseif 90.0e3 ≥ depth > 35.0e3
+                @index phases[ip, I...] = 3.0
+
+            elseif depth > 90.0e3
+                @index phases[ip, I...] = 4.0
+
+            end
+
+            # plume - rectangular
+            if ((x - Lx * 0.5)^2 ≤ r^2) && ((y - Ly * 0.5)^2 ≤ r^2) && ((depth - d)^2 ≤ r^2)
+                @index phases[ip, I...] = 5.0
+            end
+        end
+        return nothing
+    end
+
+    return @parallel (@idx ni) _init_phases!(phases, particles.coords..., particles.index, r, d, Lx, Ly)
+end
+
+# Piecewise-linear geotherm
+@parallel_indices (I...) function init_T!(T, z)
+    depth = -z[I[3]]
+
+    if depth < 0.0e0
+        T[I...] = 273.0
+
+    elseif 0.0e0 ≤ depth < 35.0e3
+        dTdZ = (923 - 273) / 35.0e3
+        offset = 273.0e0
+        T[I...] = depth * dTdZ + offset
+
+    elseif 110.0e3 > depth ≥ 35.0e3
+        dTdZ = (1492 - 923) / 75.0e3
+        offset = 923.0e0
+        T[I...] = (depth - 35.0e3) * dTdZ + offset
+
+    elseif depth ≥ 110.0e3
+        dTdZ = (1837 - 1492) / 590.0e3
+        offset = 1492.0e0
+        T[I...] = (depth - 110.0e3) * dTdZ + offset
+
+    end
+
+    return nothing
+end
+
+# Thermal rectangular perturbation, co-located with the plume
+function rectangular_perturbation!(T, xc, yc, zc, r, xvi)
+
+    @parallel_indices (i, j, k) function _rectangular_perturbation!(T, xc, yc, zc, r, x, y, z)
+        if (abs(x[i] - xc) ≤ r) && (abs(y[j] - yc) ≤ r) && (abs(z[k] - zc) ≤ r)
+            depth = abs(z[k])
+            dTdZ = (2047 - 2017) / 50.0e3
+            offset = 2017
+            T[i, j, k] = (depth - 585.0e3) * dTdZ + offset
+        end
+        return nothing
+    end
+
+    return @parallel _rectangular_perturbation!(T, xc, yc, zc, r, xvi...)
+end

--- a/miniapps/subduction/2D/Subduction2D_MPI.jl
+++ b/miniapps/subduction/2D/Subduction2D_MPI.jl
@@ -94,8 +94,6 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
     # particle fields for the stress rotation
     pτ = StressParticles(particles)
-    pτxx, pτyy = normal_stress(pτ)
-    pτxy, = shear_stress(pτ)
     particle_args = (pT, pPhases, unwrap(pτ)...)
     particle_args_reduced = (pT, unwrap(pτ)...)
 
@@ -126,11 +124,17 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         constant_value = (left = false, right = false, top = Ttop, bot = Tbot),
     )
     thermal_bcs!(thermal, thermal_bc)
+    update_halo!(thermal.T)
     # ----------------------------------------------------
 
     # Buoyancy forces
     ρg = ntuple(_ -> @zeros(ni...), Val(2))
     compute_ρg!(ρg[2], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
+    # The lithostatic profile is integrated down a whole column, which a rank only owns
+    # if the domain is not split in the vertical direction.
+    igg.dims[2] == 1 || error(
+        "the lithostatic pressure initialization requires an undecomposed vertical direction; got dims = $(igg.dims). Pass dimy = 1 to init_global_grid"
+    )
     stokes.P .= PTArray(backend)(reverse(cumsum(reverse((ρg[2]) .* di[2], dims = 2), dims = 2), dims = 2))
 
     # Rheology
@@ -217,12 +221,12 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         particle2centroid!(T_buffer, pT, particles)
         @views thermal.T[2:(end - 1), 2:(end - 1)] .= T_buffer
         thermal_bcs!(thermal, thermal_bc)
+        update_halo!(thermal.T)
 
         args = (; T = thermal.T, P = stokes.P, dt = Inf)
 
-        particle2centroid!(stokes.τ.xx, pτxx, particles)
-        particle2centroid!(stokes.τ.yy, pτyy, particles)
-        particle2grid!(stokes.τ.xy, pτxy, particles)
+        # interpolate stress back to the grid
+        stress2grid!(stokes, pτ, particles)
 
         # Stokes solver ----------------
         t_stokes = @elapsed begin
@@ -257,9 +261,6 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
         center2vertex!(τxx_v, stokes.τ.xx)
         center2vertex!(τyy_v, stokes.τ.yy)
-        centroid2particle!(pτxx, stokes.τ.xx, particles)
-        centroid2particle!(pτyy, stokes.τ.yy, particles)
-        grid2particle!(pτxy, stokes.τ.xy, particles)
         rotate_stress!(pτ, stokes, particles, dt)
 
         if igg.me == 0
@@ -269,7 +270,7 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         end
         tensor_invariant!(stokes.ε)
         tensor_invariant!(stokes.ε_pl)
-        dt = compute_dt(stokes, di) * 0.8
+        dt = compute_dt(stokes, di, igg) * 0.8
         # ------------------------------
 
         # Thermal solver ---------------
@@ -318,10 +319,9 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
         # update phase ratios
         update_phase_ratios!(phase_ratios, particles, pPhases)
-        if igg.me == 0
-            @show it += 1
-            t += dt
-        end
+        it += 1
+        t += dt
+        igg.me == 0 && @show it
 
         #MPI gathering
         phase_center = [argmax(p) for p in Array(phase_ratios.center)]
@@ -346,7 +346,7 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
             gather!(Vxv_nohalo, Vxv_v)
             gather!(Vyv_nohalo, Vyv_v)
         end
-        @views T_nohalo .= Array((@view thermal.T[2:(end - 1), 2:(end - 1)])[2:(end - 1), 2:(end - 1)]) # Copy data to CPU removing the halo
+        @views T_nohalo .= Array(thermal.T[3:(end - 2), 3:(end - 2)]) # Copy data to CPU removing the halo
         gather!(T_nohalo, T_v)
 
         # Data I/O and plotting ---------------------
@@ -419,8 +419,10 @@ do_vtk = true # set to true to generate VTK files for ParaView
 nx, ny = 128, 128
 
 
+# `dimy = 1` keeps every rank in charge of a full vertical column, which the
+# lithostatic pressure initialization needs
 igg = if !(JustRelax.MPI.Initialized()) # initialize (or not) MPI grid
-    IGG(init_global_grid(nx, ny, 1; init_MPI = true)...)
+    IGG(init_global_grid(nx, ny, 1; init_MPI = true, dimy = 1)...)
 else
     igg
 end
@@ -434,11 +436,14 @@ origin = (x_global[1], z_global[1])
 li = (abs(last(x_global) - first(x_global)), abs(last(z_global) - first(z_global)))
 
 ni = nx, ny           # number of cells
-di = @. li / (nx_g(), ny_g())           # grid steps
 grid_global = Geometry(ni, li; origin = origin)
 
 figdir = "Subduction2D_$(nx_g())x$(ny_g())"
 
-li_GMG, origin_GMG, phases_GMG, T_GMG = GMG_subduction_2D(model_depth, grid_global.xvi, nx + 1, ny + 1)
+# `grid_global.xvi` spans this rank's subdomain, so every rank builds the phase and
+# temperature fields it owns. `Geometry` and `PTStokesCoeffs` derive the grid spacing
+# from the global cell count, so they need the global domain length and origin, not the
+# per-rank extents that the setup routine reports back.
+_, _, phases_GMG, T_GMG = GMG_subduction_2D(model_depth, grid_global.xvi, nx + 1, ny + 1)
 
-main(x_global, z_global, li_GMG, origin_GMG, phases_GMG, T_GMG, igg; figdir = figdir, nx = nx, ny = ny, do_vtk = do_vtk);
+main(x_global, z_global, li .* 1.0e3, origin .* 1.0e3, phases_GMG, T_GMG, igg; figdir = figdir, nx = nx, ny = ny, do_vtk = do_vtk);

--- a/miniapps/subduction/2D/Subduction2D_MPI_original.jl
+++ b/miniapps/subduction/2D/Subduction2D_MPI_original.jl
@@ -94,8 +94,6 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
     # particle fields for the stress rotation
     pτ = StressParticles(particles)
-    pτxx, pτyy = normal_stress(pτ)
-    pτxy, = shear_stress(pτ)
     particle_args = (pT, pPhases, unwrap(pτ)...)
     particle_args_reduced = (pT, unwrap(pτ)...)
 
@@ -126,11 +124,17 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         constant_value = (left = false, right = false, top = Ttop, bot = Tbot),
     )
     thermal_bcs!(thermal, thermal_bc)
+    update_halo!(thermal.T)
     # ----------------------------------------------------
 
     # Buoyancy forces
     ρg = ntuple(_ -> @zeros(ni...), Val(2))
     compute_ρg!(ρg[2], phase_ratios, rheology, (T = thermal.T, P = stokes.P))
+    # The lithostatic profile is integrated down a whole column, which a rank only owns
+    # if the domain is not split in the vertical direction.
+    igg.dims[2] == 1 || error(
+        "the lithostatic pressure initialization requires an undecomposed vertical direction; got dims = $(igg.dims). Pass dimy = 1 to init_global_grid"
+    )
     stokes.P .= PTArray(backend)(reverse(cumsum(reverse((ρg[2]) .* di[2], dims = 2), dims = 2), dims = 2))
 
     # Rheology
@@ -217,12 +221,12 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         particle2centroid!(T_buffer, pT, particles)
         @views thermal.T[2:(end - 1), 2:(end - 1)] .= T_buffer
         thermal_bcs!(thermal, thermal_bc)
+        update_halo!(thermal.T)
 
         args = (; T = thermal.T, P = stokes.P, dt = Inf)
 
-        particle2centroid!(stokes.τ.xx, pτxx, particles)
-        particle2centroid!(stokes.τ.yy, pτyy, particles)
-        particle2grid!(stokes.τ.xy, pτxy, particles)
+        # interpolate stress back to the grid
+        stress2grid!(stokes, pτ, particles)
 
         # Stokes solver ----------------
         t_stokes = @elapsed begin
@@ -257,9 +261,6 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
         center2vertex!(τxx_v, stokes.τ.xx)
         center2vertex!(τyy_v, stokes.τ.yy)
-        centroid2particle!(pτxx, stokes.τ.xx, particles)
-        centroid2particle!(pτyy, stokes.τ.yy, particles)
-        grid2particle!(pτxy, stokes.τ.xy, particles)
         rotate_stress!(pτ, stokes, particles, dt)
 
         if igg.me == 0
@@ -269,7 +270,7 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
         end
         tensor_invariant!(stokes.ε)
         tensor_invariant!(stokes.ε_pl)
-        dt = compute_dt(stokes, di) * 0.8
+        dt = compute_dt(stokes, di, igg) * 0.8
         # ------------------------------
 
         # Thermal solver ---------------
@@ -318,10 +319,9 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
 
         # update phase ratios
         update_phase_ratios!(phase_ratios, particles, pPhases)
-        if igg.me == 0
-            @show it += 1
-            t += dt
-        end
+        it += 1
+        t += dt
+        igg.me == 0 && @show it
 
         #MPI gathering
         phase_center = [argmax(p) for p in Array(phase_ratios.center)]
@@ -346,7 +346,7 @@ function main(x_global, z_global, li, origin, phases_GMG, T_GMG, igg; nx = 16, n
             gather!(Vxv_nohalo, Vxv_v)
             gather!(Vyv_nohalo, Vyv_v)
         end
-        @views T_nohalo .= Array((@view thermal.T[2:(end - 1), 2:(end - 1)])[2:(end - 1), 2:(end - 1)]) # Copy data to CPU removing the halo
+        @views T_nohalo .= Array(thermal.T[3:(end - 2), 3:(end - 2)]) # Copy data to CPU removing the halo
         gather!(T_nohalo, T_v)
 
         # Data I/O and plotting ---------------------
@@ -417,8 +417,10 @@ do_vtk = true # set to true to generate VTK files for ParaView
 nx, ny = 128, 128
 
 
+# `dimy = 1` keeps every rank in charge of a full vertical column, which the
+# lithostatic pressure initialization needs
 igg = if !(JustRelax.MPI.Initialized()) # initialize (or not) MPI grid
-    IGG(init_global_grid(nx, ny, 1; init_MPI = true)...)
+    IGG(init_global_grid(nx, ny, 1; init_MPI = true, dimy = 1)...)
 else
     igg
 end
@@ -432,11 +434,14 @@ origin = (x_global[1], z_global[1])
 li = (abs(last(x_global) - first(x_global)), abs(last(z_global) - first(z_global)))
 
 ni = nx, ny           # number of cells
-di = @. li / (nx_g(), ny_g())           # grid steps
 grid_global = Geometry(ni, li; origin = origin)
 
 figdir = "Subduction2D_$(nx_g())x$(ny_g())"
 
-li_GMG, origin_GMG, phases_GMG, T_GMG = GMG_subduction_2D(model_depth, grid_global.xvi, nx + 1, ny + 1)
+# `grid_global.xvi` spans this rank's subdomain, so every rank builds the phase and
+# temperature fields it owns. `Geometry` and `PTStokesCoeffs` derive the grid spacing
+# from the global cell count, so they need the global domain length and origin, not the
+# per-rank extents that the setup routine reports back.
+_, _, phases_GMG, T_GMG = GMG_subduction_2D(model_depth, grid_global.xvi, nx + 1, ny + 1)
 
-main(x_global, z_global, li_GMG, origin_GMG, phases_GMG, T_GMG, igg; figdir = figdir, nx = nx, ny = ny, do_vtk = do_vtk);
+main(x_global, z_global, li .* 1.0e3, origin .* 1.0e3, phases_GMG, T_GMG, igg; figdir = figdir, nx = nx, ny = ny, do_vtk = do_vtk);

--- a/miniapps/subduction/3D/Subduction3D_MPI.jl
+++ b/miniapps/subduction/3D/Subduction3D_MPI.jl
@@ -213,7 +213,7 @@ function main3D(x_global, y_global, z_global, li, origin, phases_GMG, igg; nx = 
             println("   Time/iteration:  $(t_stokes / out.iter) s")
         end
         tensor_invariant!(stokes.ε)
-        dt = compute_dt(stokes, di)
+        dt = compute_dt(stokes, di, igg)
         # ------------------------------
 
         # Advection --------------------
@@ -229,10 +229,9 @@ function main3D(x_global, y_global, z_global, li, origin, phases_GMG, igg; nx = 
         inject_particles_phase!(particles, pPhases, (), ())
         # update phase ratios
         update_phase_ratios!(phase_ratios, particles, pPhases)
-        if igg.me == 0
-            @show it += 1
-            t += dt
-        end
+        it += 1
+        t += dt
+        igg.me == 0 && @show it
 
         #MPI gathering
         phase_center = [argmax(p) for p in Array(phase_ratios.center)]
@@ -260,7 +259,7 @@ function main3D(x_global, y_global, z_global, li, origin, phases_GMG, igg; nx = 
             gather!(Vyv_nohalo, Vyv_v)
             gather!(Vzv_nohalo, Vzv_v)
         end
-        @views T_nohalo .= Array(thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)]) # Copy data to CPU removing the halo
+        @views T_nohalo .= Array(thermal.T[3:(end - 2), 3:(end - 2), 3:(end - 2)]) # Copy data to CPU removing the halo
         gather!(T_nohalo, T_v)
 
         # Data I/O and plotting ---------------------


### PR DESCRIPTION
Adds an MPI version of the 3D plume miniapp, factors the model definition it shares with the serial script, and makes the MPI subduction miniapps actually run.

## 3D plume

`Plume3D_rheology.jl` now holds the rheology, the phase layering, the geotherm and the thermal anomaly; `Plume3D.jl` and the new `Plume3D_MPI.jl` both include it. `Plume3D.jl` drops from 451 to 287 lines and is otherwise unchanged.

`Plume3D_MPI.jl` differs from the serial script in the places where the decomposition matters:

- grid spacing from the global cell count (`li ./ (nx_g(), ny_g(), nz_g())`), with `li`/`origin` describing the global domain
- lithostatic pressure from the global depth coordinate — a cumulative sum down the column only sees one subdomain
- `update_cell_halo!` for the particles after initialization and after advection, `update_halo!(thermal.T)` after each particle-to-centroid interpolation
- `compute_dt(stokes, di, dt_diff, igg)`, so the velocity maximum is a global reduction
- output gathered to rank 0 and written as a single VTK per step; no Makie

Verified on 4 ranks under both a 2×2×1 and a pure 1×1×4 (vertical) decomposition: no zeros in the gathered arrays, temperature monotonic across rank boundaries.

## Subduction miniapps

`Subduction2D_MPI.jl` did not load, and once loading it diverged. Five separate problems:

1. **`normal_stress` / `shear_stress` are not exported** from `JustRelax2D`, so the script failed at `UndefVarError`. Replaced with `stress2grid!(stokes, pτ, particles)` and `rotate_stress!(pτ, stokes, particles, dt)`, matching the serial script. This also fixes two omissions in the hand-rolled version: it wrote `stokes.τ` rather than `stokes.τ_o` and skipped the vertex components, and it never interpolated the vorticity onto the particles.
2. **`@view` nested inside `@views`** in the gather buffer copy — not a valid reference expression, `ArgumentError` at include time.
3. **Local vs global domain extents.** `GMG_subduction_2D` builds from the rank-local `xvi` and returns the rank-local `li`/`origin`; `main` passed those to `Geometry` and `PTStokesCoeffs`, which divide by the *global* cell count. Grid spacing was wrong by the rank count in each direction — this is why it converged on one rank and blew up on two. The entry point now passes the global values; the GMG fields stay per-rank.
4. **Stale thermal halo** after the particle-to-centroid interpolation.
5. **Time step.** `compute_dt(stokes, di, igg)` so all ranks agree, and `it`/`t` advance on every rank instead of only on rank 0 — previously the other ranks sat at `it = 0` against a `while it < 1000` loop condition.

In 3D, the same time-step fix plus a gather buffer that was filled from an `n³` slice into an `(n-2)³` array.

### Vertical decomposition

The 2D lithostatic profile is a cumulative sum down a column, so a rank has to own the whole column. I tried replacing it with the pointwise `init_P!` kernel used elsewhere, but with a sticky-air layer that is a much worse initial guess and it diverged. Instead the grid is initialized with `dimy = 1` and `main` checks the constraint before seeding the pressure, so an override fails immediately with a clear message rather than NaN-ing thousands of PT iterations later.

## Verification

| script | ranks | result |
|---|---|---|
| `Plume3D.jl` | serial | runs |
| `Plume3D_MPI.jl` | 1, 4 (2×2×1 and 1×1×4) | runs, gather checked |
| `Subduction2D_MPI.jl` | 1, 2, 4 | runs, all ranks agree on `t` and `dt` |
| `Subduction2D_MPI.jl` | forced `dimy = 2` | fails immediately with the intended message |
| `Subduction3D_MPI.jl` | — | **not run** |

All at reduced resolution and a few time steps. `Subduction3D_MPI.jl` carries the same shape of fix but its setup is 150×40×150 and each Stokes solve takes tens of thousands of PT iterations, so I did not run it — worth a look from someone with the machine time.

Everything is `runic` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
