### PR TITLE
[BUGFIX] Fix plasticity bug in stress_kernel

### DIFF
--- a/src/DYREL/stress_kernels.jl
+++ b/src/DYREL/stress_kernels.jl
@@ -276,7 +276,8 @@ end
     # dQdτ is already in tensor convention (shear slots halved inside _plastic_grad_primitive)
 
     λ, ε_vol_pl = if ispl && F ≥ 0
-        λ_new = F / (η_ve + η_reg + Kb * dt * dFdP * dQdP)
+        bulk_plastic = isinf(Kb) ? zero(η_ve) : Kb * dt * dFdP * dQdP
+        λ_new = F / (η_ve + η_reg + bulk_plastic)
         λ = λ_relaxation * λ_new + (1 - λ_relaxation) * λ
         # Volumetric plastic strain rate
         ε_vol_pl = -λ * dQdP


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**
In the _compute_local_stress kernel, the plastic multiplier λ_new became NaN for the combination of incompressible elasticity and non-dilatant plasticity. In this case, Kb = Inf and dQdP = 0.0, so that Inf * 0.0 = NaN and preventing the plastic stress correction from being applied

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [x] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [x] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
