### PR TITLE
[BUGFIX][FEATURE] Vtk single file & fixed velocity vector

### DIFF
--- a/miniapps/DYREL2D/convection/GlobalConvection2D_DYREL_refined.jl
+++ b/miniapps/DYREL2D/convection/GlobalConvection2D_DYREL_refined.jl
@@ -401,7 +401,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 data_v = (;
-                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                     εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                     Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                     Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/DYREL2D/convection/Layered_convection2D_DYREL.jl
+++ b/miniapps/DYREL2D/convection/Layered_convection2D_DYREL.jl
@@ -326,7 +326,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 data_v = (;
-                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                     εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                     Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                     Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/DYREL2D/convection/Layered_convection2D_DYREL_refined.jl
+++ b/miniapps/DYREL2D/convection/Layered_convection2D_DYREL_refined.jl
@@ -383,7 +383,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 data_v = (;
-                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                     εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                     Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                     Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/DYREL2D/thermal_stress/Thermal_Stress_Magma_Chamber_nondim.jl
+++ b/miniapps/DYREL2D/thermal_stress/Thermal_Stress_Magma_Chamber_nondim.jl
@@ -486,7 +486,7 @@ function main2D(igg; figdir = "Thermal_stresses", nx = 32, ny = 32, do_vtk = fal
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 if do_vtk
                     data_v = (;
-                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                         εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                         Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                         Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/benchmarks/stokes2D/Blankenbach2D/Benchmark2D_sgd_scaled.jl
+++ b/miniapps/benchmarks/stokes2D/Blankenbach2D/Benchmark2D_sgd_scaled.jl
@@ -272,7 +272,7 @@ function main2D(igg; ar = 1, nx = 32, ny = 32, nit = 1.0e1, figdir = "figs2D", d
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 data_v = (;
-                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                     εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                     Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                     Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/benchmarks/stokes3D/StickyAirSubduction/Subduction3D.jl
+++ b/miniapps/benchmarks/stokes3D/StickyAirSubduction/Subduction3D.jl
@@ -175,7 +175,7 @@ function main3D(li, origin, phases_GMG, igg; nx = 16, ny = 16, nz = 16, figdir =
             if do_vtk
                 # velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
                 data_v = (;
-                    phase_vertex = [argmax(p) for p in Array(phase_ratios.center)],
+                    phase_vertex = [argmax(p) for p in Array(phase_ratios.vertex)],
                 )
                 data_c = (;
                     P = Array(stokes.P),

--- a/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim.jl
+++ b/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim.jl
@@ -477,7 +477,7 @@ function main2D(igg; figdir = "Thermal_stresses", nx = 32, ny = 32, do_vtk = fal
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 if do_vtk
                     data_v = (;
-                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                         εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                         Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                         Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim3D.jl
+++ b/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim3D.jl
@@ -437,8 +437,6 @@ function main3D(igg; figdir = "output", nx = 64, ny = 64, nz = 64, do_vtk = fals
                 if do_vtk
                     velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
                     data_v = (;
-                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
-                        εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                         Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                         Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),
                         Vz = Array(ustrip.(dimensionalize(Vz_v, cm / yr, CharDim))),
@@ -449,10 +447,12 @@ function main3D(igg; figdir = "output", nx = 64, ny = 64, nz = 64, do_vtk = fals
                         τxx = Array(ustrip.(dimensionalize(stokes.τ.xx, MPa, CharDim))),
                         τyy = Array(ustrip.(dimensionalize(stokes.τ.yy, MPa, CharDim))),
                         τzz = Array(ustrip.(dimensionalize(stokes.τ.zz, MPa, CharDim))),
+                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy_c, MPa, CharDim))),
                         τII = Array(ustrip.(dimensionalize(stokes.τ.II, MPa, CharDim))),
                         εxx = Array(ustrip.(dimensionalize(stokes.ε.xx, s^-1, CharDim))),
                         εyy = Array(ustrip.(dimensionalize(stokes.ε.yy, s^-1, CharDim))),
                         εzz = Array(ustrip.(dimensionalize(stokes.ε.zz, s^-1, CharDim))),
+                        εxy = Array(ustrip.(dimensionalize(stokes.ε.xy_c, s^-1, CharDim))),
                         εII = Array(ustrip.(dimensionalize(stokes.ε.II, s^-1, CharDim))),
                         η = Array(ustrip.(dimensionalize(stokes.viscosity.η_vep, Pa * s, CharDim))),
                     )

--- a/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim_VS.jl
+++ b/miniapps/benchmarks/thermal_stress/Thermal_Stress_Magma_Chamber_nondim_VS.jl
@@ -529,7 +529,7 @@ function main2D(igg; εbg_0 = 0.0e0, linear_rheology = true, figdir = figdir, nx
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 if do_vtk
                     data_v = (;
-                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                         εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                         Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                         Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/convection/Particles2D_nonDim/Layered_convection2D.jl
+++ b/miniapps/convection/Particles2D_nonDim/Layered_convection2D.jl
@@ -291,7 +291,7 @@ function main2D(igg; ar = 8, ny = 16, nx = ny * 8, figdir = "figs2D", do_vtk = f
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, @velocity(stokes)...)
                 data_v = (;
-                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
+                    τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, MPa, CharDim))),
                     εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
                     Vx = Array(ustrip.(dimensionalize(Vx_v, cm / yr, CharDim))),
                     Vy = Array(ustrip.(dimensionalize(Vy_v, cm / yr, CharDim))),

--- a/miniapps/convection/Particles3D/Layered_convection3D.jl
+++ b/miniapps/convection/Particles3D/Layered_convection3D.jl
@@ -270,17 +270,16 @@ function main3D(igg; ar = 1, nx = 16, ny = 16, nz = 16, figdir = "figs3D", do_vt
 
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
-                data_v = (;
-                    τxy = Array(stokes.τ.xy),
-                    εxy = Array(stokes.ε.xy),
-                )
+                data_v = (;)
                 data_c = (;
                     T = Array(thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)]),
                     P = Array(stokes.P),
                     τxx = Array(stokes.τ.xx),
                     τyy = Array(stokes.τ.yy),
+                    τxy = Array(stokes.τ.xy_c),
                     εxx = Array(stokes.ε.xx),
                     εyy = Array(stokes.ε.yy),
+                    εxy = Array(stokes.ε.xy_c),
                     η = Array(log10.(stokes.viscosity.η_vep)),
                 )
                 velocity_v = (

--- a/miniapps/convection/RisingBlob3D/Blob3D.jl
+++ b/miniapps/convection/RisingBlob3D/Blob3D.jl
@@ -434,20 +434,19 @@ function main3D(igg; figdir = "output", nx = 64, ny = 64, nz = 64, do_vtk = fals
             if igg.me == 0
                 if do_vtk
                     velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
-                    data_v = (;
-                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy, s^-1, CharDim))),
-                        εxy = Array(ustrip.(dimensionalize(stokes.ε.xy, s^-1, CharDim))),
-                    )
+                    data_v = (;)
                     data_c = (;
                         P = Array(ustrip.(dimensionalize(stokes.P, MPa, CharDim))),
                         T = Array(ustrip.(dimensionalize(thermal.T[2:(end - 1), 2:(end - 1), 2:(end - 1)], C, CharDim))),
                         τxx = Array(ustrip.(dimensionalize(stokes.τ.xx, MPa, CharDim))),
                         τyy = Array(ustrip.(dimensionalize(stokes.τ.yy, MPa, CharDim))),
                         τzz = Array(ustrip.(dimensionalize(stokes.τ.zz, MPa, CharDim))),
+                        τxy = Array(ustrip.(dimensionalize(stokes.τ.xy_c, MPa, CharDim))),
                         τII = Array(ustrip.(dimensionalize(stokes.τ.II, MPa, CharDim))),
                         εxx = Array(ustrip.(dimensionalize(stokes.ε.xx, s^-1, CharDim))),
                         εyy = Array(ustrip.(dimensionalize(stokes.ε.yy, s^-1, CharDim))),
                         εzz = Array(ustrip.(dimensionalize(stokes.ε.zz, s^-1, CharDim))),
+                        εxy = Array(ustrip.(dimensionalize(stokes.ε.xy_c, s^-1, CharDim))),
                         εII = Array(ustrip.(dimensionalize(stokes.ε.II, s^-1, CharDim))),
                         η = Array(ustrip.(dimensionalize(stokes.viscosity.η, Pa * s, CharDim))),
                     )

--- a/miniapps/subduction/3D/Subduction3D.jl
+++ b/miniapps/subduction/3D/Subduction3D.jl
@@ -211,7 +211,7 @@ function main3D(li, origin, phases_GMG, igg; nx = 16, ny = 16, nz = 16, figdir =
             if do_vtk
                 velocity2vertex!(Vx_v, Vy_v, Vz_v, @velocity(stokes)...)
                 data_v = (;
-                    phase_vertex = [argmax(p) for p in Array(phase_ratios.center)],
+                    phase_vertex = [argmax(p) for p in Array(phase_ratios.vertex)],
                 )
                 data_c = (;
                     P = dimensionalize_and_strip(Array(stokes.P), Pa, CharDim),

--- a/src/IO/VTK.jl
+++ b/src/IO/VTK.jl
@@ -1,3 +1,56 @@
+"""
+    pack_velocity(velocity::Tuple, precision, slices = nothing)
+
+Pack the velocity components into the `(3, size...)` array expected for a VTK
+vector attribute. Readers copy three values per tuple regardless of the declared
+`NumberOfComponents`, so a two-component array leaves the third component
+undefined and ParaView orients its glyphs from uninitialized memory. Components
+beyond `N` are written as zeros.
+
+`slices` optionally restricts each component to a sub-range (used to trim the
+ghost layer of MPI-distributed arrays).
+"""
+function pack_velocity(velocity::Tuple, precision, slices = nothing)
+    length(velocity) ≤ 3 ||
+        throw(ArgumentError("velocity must have at most 3 components, got $(length(velocity))"))
+    for v in velocity
+        axes(v) == axes(first(velocity)) ||
+            throw(DimensionMismatch("velocity components must share their axes: $(axes(v)) vs $(axes(first(velocity)))"))
+    end
+
+    sz = isnothing(slices) ? size(first(velocity)) : length.(slices)
+    velocity_field = zeros(precision, 3, sz...)
+    for (i, v) in enumerate(velocity)
+        vi = precision.(Array(v))
+        selectdim(velocity_field, 1, i) .= isnothing(slices) ? vi : view(vi, slices...)
+    end
+    return velocity_field
+end
+
+"""
+    add_field!(vtk, name, array, npoints, ncells, precision)
+
+Write `array` to `vtk` as point data or cell data, whichever its size matches.
+A vertex grid holds one cell fewer than it has nodes per dimension, so the two
+sizes are always distinguishable.
+"""
+function add_field!(vtk, name, array, npoints, ncells, precision)
+    data = precision.(Array(array))
+    location = if size(data) == npoints
+        VTKPointData()
+    elseif size(data) == ncells
+        VTKCellData()
+    else
+        throw(
+            DimensionMismatch(
+                "$name has size $(size(data)), which matches neither the $npoints vertices nor the $ncells cells of the grid"
+            )
+        )
+    end
+    vtk[string(name), location] = data
+    return nothing
+end
+
 struct VTKDataSeries{T, S, G}
     series::T
     path::S
@@ -44,21 +97,23 @@ end
 """
     save_vtk(fname::String, xvi, xci, data_v::NamedTuple, data_c::NamedTuple, velocity; t=0, pvd=nothing)
 
-Save VTK data with multiblock format containing both vertex and cell data.
+Save vertex and cell data to a single VTK file. The file holds the grid spanned
+by the vertices `xvi`; `data_v` and `velocity` are written as point data and
+`data_c` as cell data of that same grid.
 
 ## Arguments
 - `fname::String`: The filename for the VTK file (without extension)
 - `xvi`: Vertex coordinates (tuple of coordinate arrays)
-- `xci`: Cell center coordinates (tuple of coordinate arrays)
+- `xci`: Cell center coordinates (tuple of coordinate arrays); must have one entry fewer per dimension than `xvi`
 - `data_v::NamedTuple`: Data defined at vertices
-- `data_c::NamedTuple`: Data defined at cell centers
-- `velocity::NTuple{N, T}`: Velocity field as a tuple of N-dimensional arrays
+- `data_c::NamedTuple`: Data defined at cell centers. Fields of `data_v` and `data_c` are written as point or cell data according to their size, so a cell-centered field passed in `data_v` still lands on the cells
+- `velocity::Tuple`: Velocity components, each an array defined at the vertices
 - `t::Number`: Time value (default: 0)
 - `pvd::Union{Nothing, String}`: Optional ParaView collection filename. If provided, the VTK file will be added to a time series collection. WriteVTK.jl automatically handles creating new collections or appending to existing ones.
 
 ## Examples
 ```julia
-# Basic usage (backward compatible)
+# Basic usage
 save_vtk("output", xvi, xci, data_v, data_c, velocity; t=1.0)
 
 # With ParaView collection for time series
@@ -80,45 +135,39 @@ function save_vtk(
         xci,
         data_v::NamedTuple,
         data_c::NamedTuple,
-        velocity::NTuple{N, T};
+        velocity::Tuple;
         precision = Float32,
         t::Number = 0,
         pvd::Union{Nothing, String} = nothing,
-    ) where {N, T}
+    )
 
-    # unpack data names and arrays
-    data_names_v = string.(keys(data_v))
-    data_arrays_v = values(data_v)
-    data_names_c = string.(keys(data_c))
-    data_arrays_c = values(data_c)
+    length.(xvi) == length.(xci) .+ 1 || throw(
+        DimensionMismatch(
+            "the vertex grid must have one node more per dimension than the center grid: $(length.(xvi)) vs $(length.(xci))"
+        )
+    )
 
-    velocity_field = rand(N, size(first(velocity))...)
-    for (i, v) in enumerate(velocity)
-        velocity_field[i, :, :, :] = precision.(Array(v))
-    end
+    size(first(velocity)) == length.(xvi) || throw(
+        DimensionMismatch(
+            "velocity must be given on the vertices: $(size(first(velocity))) vs $(length.(xvi))"
+        )
+    )
 
-    vtk_multiblock(fname) do vtm
-        # First block.
-        # Variables stores in cell centers
-        vtk_grid(vtm, xci...) do vtk
-            for (name_i, array_i) in zip(data_names_c, data_arrays_c)
-                vtk[name_i] = precision.(Array(array_i))
-            end
+    velocity_field = pack_velocity(velocity, precision)
+
+    # A grid spanned by the vertices carries the cell-centered fields as cell
+    # data, so vertex and center fields share one file and one geometry.
+    vtk_grid(fname, xvi...) do vtk
+        for (name_i, array_i) in Iterators.flatten((pairs(data_v), pairs(data_c)))
+            add_field!(vtk, name_i, array_i, length.(xvi), length.(xci), precision)
         end
-        # Second block.
-        # Variables stores in cell vertices
-        vtk_grid(vtm, xvi...) do vtk
-            for (name_i, array_i) in zip(data_names_v, data_arrays_v)
-                vtk[name_i] = precision.(Array(array_i))
-            end
-            vtk["Velocity"] = velocity_field
-            isnothing(t) || (vtk["TimeValue"] = t)
-        end
+        vtk["Velocity", VTKPointData()] = velocity_field
+        isnothing(t) || (vtk["TimeValue"] = t)
 
         # If pvd collection name is provided, add this file to the collection
         if !isnothing(pvd)
             paraview_collection(pvd; append = true) do pvd_collection
-                collection_add_timestep(pvd_collection, vtm, t)
+                collection_add_timestep(pvd_collection, vtk, t)
             end
         end
     end
@@ -135,7 +184,7 @@ Save VTK data with cell-centered data and velocity field.
 - `fname::String`: The filename for the VTK file (without extension)
 - `xci`: Cell center coordinates (tuple of coordinate arrays)
 - `data_c::NamedTuple`: Data defined at cell centers
-- `velocity::NTuple{N, T}`: Velocity field as a tuple of N-dimensional arrays
+- `velocity::Tuple`: Velocity components, each an array defined on the grid nodes
 - `t::Number`: Time value (default: nothing)
 - `pvd::Union{Nothing, String}`: Optional ParaView collection filename. If provided, the VTK file will be added to a time series collection. WriteVTK.jl automatically handles creating new collections or appending to existing ones.
 
@@ -152,20 +201,25 @@ function save_vtk(
         fname::String,
         xci,
         data_c::NamedTuple,
-        velocity::NTuple{N, T};
+        velocity::Tuple;
         precision = Float32,
         t::Union{Number, Nothing} = nothing,
         pvd::Union{Nothing, String} = nothing
-    ) where {N, T}
+    )
+
+    # A velocity that does not match the grid is demoted to field data by
+    # WriteVTK, i.e. silently written as something ParaView cannot plot.
+    size(first(velocity)) == length.(xci) || throw(
+        DimensionMismatch(
+            "velocity must be given on the grid nodes: $(size(first(velocity))) vs $(length.(xci))"
+        )
+    )
 
     # unpack data names and arrays
     data_names_c = string.(keys(data_c))
     data_arrays_c = values(data_c)
 
-    velocity_field = rand(N, size(first(velocity))...)
-    for (i, v) in enumerate(velocity)
-        velocity_field[i, :, :, :] = precision.(Array(v))
-    end
+    velocity_field = pack_velocity(velocity, precision)
 
     # Create the VTK file
     vtk_grid(fname, xci...) do vtk
@@ -227,13 +281,8 @@ function _save_pvtk(
             pvtk[string(name_i)] = view(precision.(Array(array_i)), sl...)
         end
         if !isnothing(velocity)
-            # pack the velocity components into a single (Nv, extent...) array
             sl = ImplicitGlobalGrid.extents(first(velocity), 1)
-            velocity_field = zeros(precision, length(velocity), length.(sl)...)
-            for (i, v) in enumerate(velocity)
-                selectdim(velocity_field, 1, i) .= view(precision.(Array(v)), sl...)
-            end
-            pvtk["Velocity"] = velocity_field
+            pvtk["Velocity"] = pack_velocity(velocity, precision, sl)
         end
         isnothing(t) || (pvtk["TimeValue"] = t)
         # only the main rank (part 1) writes the header, so only it touches the pvd
@@ -247,9 +296,9 @@ function _save_pvtk(
 end
 
 """
-    save_pvtk(fname, di::NTuple{N}, data_v::NamedTuple, data_c::NamedTuple, velocity::NTuple, igg::IGG; t=nothing, precision=Float32, pvd=nothing)
+    save_pvtk(fname, di::NTuple{N}, data_v::NamedTuple, data_c::NamedTuple, velocity::Tuple, igg::IGG; t=nothing, precision=Float32, pvd=nothing)
 
-Parallel (MPI) counterpart of the multiblock serial `save_vtk` for an
+Parallel (MPI) counterpart of the serial `save_vtk` for an
 `ImplicitGlobalGrid`-distributed grid (requires ImplicitGlobalGrid ≥ 0.17).
 Writes vertex fields `data_v` + `velocity` to `<fname>_vertex.pvti` and cell
 fields `data_c` to `<fname>_center.pvti`, one `.vti` piece per rank. `di` is the
@@ -262,12 +311,12 @@ function save_pvtk(
         di::NTuple{N, T},
         data_v::NamedTuple,
         data_c::NamedTuple,
-        velocity::NTuple{Nv, VT},
+        velocity::Tuple,
         igg::IGG;
         t::Union{Nothing, Number} = nothing,
         precision = Float32,
         pvd::Union{Nothing, String} = nothing,
-    ) where {N, T, Nv, VT}
+    ) where {N, T}
     pvd_v = isnothing(pvd) ? nothing : pvd * "_vertex"
     pvd_c = isnothing(pvd) ? nothing : pvd * "_center"
     _save_pvtk(fname * "_vertex", di, data_v, velocity, igg, t, precision, pvd_v)
@@ -279,12 +328,12 @@ function save_pvtk(
         fname::String,
         di::NTuple{N, T},
         data::NamedTuple,
-        velocity::NTuple{Nv, VT},
+        velocity::Tuple,
         igg::IGG;
         t::Union{Nothing, Number} = nothing,
         precision = Float32,
         pvd::Union{Nothing, String} = nothing,
-    ) where {N, T, Nv, VT}
+    ) where {N, T}
     _save_pvtk(fname, di, data, velocity, igg, t, precision, pvd)
     return nothing
 end

--- a/test/test_IO.jl
+++ b/test/test_IO.jl
@@ -125,22 +125,57 @@ using WriteVTK, JLD2
             t = time,
             pvd = joinpath(dst, "pvd_test"),
         )
-        @test isfile(joinpath(dst, "vtk_000001_1.vti"))
-        @test isfile(joinpath(dst, "vtk_000001_2.vti"))
-        @test isfile(joinpath(dst, "vtk_000001.vtm"))
+        @test isfile(joinpath(dst, "vtk_000001.vti"))
         @test isfile(joinpath(dst, "pvd_test.pvd"))
 
+        # vertex and center fields share one file: point data and cell data
+        vtk_str = String(read(joinpath(dst, "vtk_000001.vti")))
+        for name_i in (keys(data_v)..., keys(data_c)...)
+            @test occursin("Name=\"$name_i\"", vtk_str)
+        end
+        point_data = vtk_str[findfirst("<PointData", vtk_str)[1]:findfirst("</PointData", vtk_str)[1]]
+        cell_data = vtk_str[findfirst("<CellData", vtk_str)[1]:findfirst("</CellData", vtk_str)[1]]
+        @test occursin("Name=\"Velocity\"", point_data)
+        # fields land where their size fits, not in the group they were passed in:
+        # Vx is given on the vertices, τII on the cell centers
+        @test occursin("Name=\"Vx\"", point_data)
+        @test occursin("Name=\"τII\"", cell_data)
+        @test occursin("Name=\"P\"", cell_data)
+        @test_throws DimensionMismatch save_vtk(
+            joinpath(dst, "vtk_bad"), xvi, xci, (; bad = zeros(nx + 2, ny + 2)),
+            data_c, velocity_v
+        )
 
+        # VTK vectors carry three components; the out-of-plane one is zero in 2D
+        @test occursin("Name=\"Velocity\" NumberOfComponents=\"3\"", point_data)
+        Vpacked = DataIO.pack_velocity(velocity_v, Float32)
+        @test size(Vpacked) == (3, size(Vx_v)...)
+        @test Vpacked[1, :, :] == Float32.(Array(Vx_v))
+        @test Vpacked[2, :, :] == Float32.(Array(Vy_v))
+        @test all(iszero, Vpacked[3, :, :])
+        @test_throws DimensionMismatch DataIO.pack_velocity(
+            (Vx_v, view(Vy_v, :, 1:(size(Vy_v, 2) - 1))), Float32
+        )
+
+        # the vertex grid must bound the cell grid, and velocity must live on the nodes
+        @test_throws DimensionMismatch save_vtk(
+            joinpath(dst, "vtk_bad"), xci, xci, data_v, data_c, velocity_v
+        )
+        @test_throws DimensionMismatch save_vtk(
+            joinpath(dst, "vtk_bad"), xci, data_c, velocity_v
+        )
+
+        velocity_c = (Array(stokes.V.Vx[1:nx, 1:ny]), Array(stokes.V.Vy[1:nx, 1:ny]))
         save_vtk(
-            joinpath(dst, "vtk_" * lpad("1", 6, "0")),
+            joinpath(dst, "vtk_center_" * lpad("1", 6, "0")),
             xci,
             data_c,
-            velocity_v,
+            velocity_c,
             t = time,
             pvd = joinpath(dst, "pvd_test1"),
         )
 
-        @test isfile(joinpath(dst, "vtk_000001.vti"))
+        @test isfile(joinpath(dst, "vtk_center_000001.vti"))
         @test isfile(joinpath(dst, "pvd_test1.pvd"))
 
         save_vtk(
@@ -176,7 +211,7 @@ using WriteVTK, JLD2
         @test isfile(joinpath(dst, "MarkerChainPVD.vtp"))
         @test isfile(joinpath(dst, "markerchain_pvd.pvd"))
 
-        save_vtk(joinpath(dst, "vtk_default_t"), xci, data_c, velocity_v)
+        save_vtk(joinpath(dst, "vtk_default_t"), xci, data_c, velocity_c)
         @test isfile(joinpath(dst, "vtk_default_t.vti"))
 
         # save_particles (2D) with and without phases


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**
Both cell center and vertex fields are now living on the same VTK files. Velocity is now also correclty saved as a vector, so that the Glyph filter works without having to use the Calculator.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [x] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/PTsolvers/JustRelax.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
